### PR TITLE
docs: document the ISOCODE_3166_2 output of the state loop

### DIFF
--- a/docs/reference/loops/State.md
+++ b/docs/reference/loops/State.md
@@ -19,15 +19,16 @@ Plus the [global arguments](./global_arguments)
 
 ## Outputs
 
-| Variable       | Value                                          |
-|:---------------|:-----------------------------------------------|
-| $COUNTRY       | the country the state belongs                  |
-| $ID            | the state id                                   |
-| $ISOCODE       | the state ISO code                             |
-| $IS_TRANSLATED | check if the state is translated               |
-| $LOCALE        | The locale used for this research              |
-| $TITLE         | the state title                                |
-| $VISIBLE       | true if the state is visible. False otherwise  |
+| Variable        | Value                                                     |
+|:----------------|:----------------------------------------------------------|
+| $COUNTRY        | the country the state belongs                             |
+| $ID             | the state id                                              |
+| $ISOCODE        | the state ISO code                                        |
+| $ISOCODE_3166_2 | the full ISO 3166-2 code of the state, for instance US-CA |
+| $IS_TRANSLATED  | check if the state is translated                          |
+| $LOCALE         | The locale used for this research                         |
+| $TITLE          | the state title                                           |
+| $VISIBLE        | true if the state is visible. False otherwise             |
 
 Plus the [global outputs](./global_outputs)
 

--- a/versioned_docs/version-2.x/loops/State.md
+++ b/versioned_docs/version-2.x/loops/State.md
@@ -19,15 +19,16 @@ Plus the [global arguments](./global_arguments)
 
 ## Outputs
 
-| Variable       | Value                                          |
-|:---------------|:-----------------------------------------------|
-| $COUNTRY       | the country the state belongs                  |
-| $ID            | the state id                                   |
-| $ISOCODE       | the state ISO code                             |
-| $IS_TRANSLATED | check if the state is translated               |
-| $LOCALE        | The locale used for this research              |
-| $TITLE         | the state title                                |
-| $VISIBLE       | true if the state is visible. False otherwise  |
+| Variable        | Value                                                     |
+|:----------------|:----------------------------------------------------------|
+| $COUNTRY        | the country the state belongs                             |
+| $ID             | the state id                                              |
+| $ISOCODE        | the state ISO code                                        |
+| $ISOCODE_3166_2 | the full ISO 3166-2 code of the state, for instance US-CA |
+| $IS_TRANSLATED  | check if the state is translated                          |
+| $LOCALE         | The locale used for this research                         |
+| $TITLE          | the state title                                           |
+| $VISIBLE        | true if the state is visible. False otherwise             |
 
 Plus the [global outputs](./global_outputs)
 

--- a/versioned_docs/version-3.0/reference/loops/State.md
+++ b/versioned_docs/version-3.0/reference/loops/State.md
@@ -19,15 +19,16 @@ Plus the [global arguments](./global_arguments)
 
 ## Outputs
 
-| Variable       | Value                                          |
-|:---------------|:-----------------------------------------------|
-| $COUNTRY       | the country the state belongs                  |
-| $ID            | the state id                                   |
-| $ISOCODE       | the state ISO code                             |
-| $IS_TRANSLATED | check if the state is translated               |
-| $LOCALE        | The locale used for this research              |
-| $TITLE         | the state title                                |
-| $VISIBLE       | true if the state is visible. False otherwise  |
+| Variable        | Value                                                     |
+|:----------------|:----------------------------------------------------------|
+| $COUNTRY        | the country the state belongs                             |
+| $ID             | the state id                                              |
+| $ISOCODE        | the state ISO code                                        |
+| $ISOCODE_3166_2 | the full ISO 3166-2 code of the state, for instance US-CA |
+| $IS_TRANSLATED  | check if the state is translated                          |
+| $LOCALE         | The locale used for this research                         |
+| $TITLE          | the state title                                           |
+| $VISIBLE        | true if the state is visible. False otherwise             |
 
 Plus the [global outputs](./global_outputs)
 


### PR DESCRIPTION
The state loop has exposed `$ISOCODE_3166_2` since the ISO 3166-2 accessor landed, but none of the three output tables listed it, so the output was undiscoverable.

Adds the row to the current 3.0 docs, the versioned 3.0 docs and the versioned 2.x docs.

Refs thelia/thelia#3168