### PR TITLE
docs: replace bin/console with php Thelia

### DIFF
--- a/docs/architecture/dual-templating.md
+++ b/docs/architecture/dual-templating.md
@@ -149,8 +149,8 @@ ddev exec php bin/install \
   --with-demo --with-admin
 
 # already installed: switch active back-office template
-ddev exec bin/console template:set backOffice default-twig
-ddev exec bin/console cache:warmup -e dev
+ddev exec php Thelia template:set backOffice default-twig
+ddev exec php Thelia cache:warmup -e dev
 
 # build assets
 ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"

--- a/docs/back-office/bundle-structure.md
+++ b/docs/back-office/bundle-structure.md
@@ -55,7 +55,7 @@ when it is the active admin template. `isActive()` compares its own name against
 
 Both `loadExtension()` and `prependExtension()` early-return when `isActive()` is `false`. The
 back-office you select with `bin/install --backoffice_theme=default-twig` (or
-`bin/console template:set backOffice default-twig`) is the only one whose services enter the
+`php Thelia template:set backOffice default-twig`) is the only one whose services enter the
 container.
 
 :::tip

--- a/docs/back-office/components.md
+++ b/docs/back-office/components.md
@@ -270,7 +270,7 @@ ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
 :::caution Rebuild after editing assets
 A SCSS or controller change is only visible after an Encore rebuild
 (`npm run build` or a running `npm run watch`). After editing a Twig template,
-clear the cache: `ddev exec bin/console cache:clear -e dev`.
+clear the cache: `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Learn more

--- a/docs/back-office/index.md
+++ b/docs/back-office/index.md
@@ -44,8 +44,8 @@ ddev exec php bin/install \
   --admin_email=thelia@example.com
 
 # already installed - switch the active back-office template
-ddev exec bin/console template:set backOffice default-twig
-ddev exec bin/console cache:warmup -e dev
+ddev exec php Thelia template:set backOffice default-twig
+ddev exec php Thelia cache:warmup -e dev
 
 # build the bundle assets (SCSS + JS)
 ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
@@ -56,7 +56,7 @@ The admin is then available at `https://<your-site>.ddev.site/admin`.
 :::tip Watch assets during development
 While editing SCSS or Stimulus controllers, run `npm run watch` from
 `templates/backOffice/default-twig/` so the bundle assets rebuild automatically. After editing a
-Twig template, clear the cache with `ddev exec bin/console cache:clear -e dev`.
+Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Bundle structure

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -11,11 +11,11 @@ Thelia ships a console application built on the [Symfony Console component](http
 php Thelia <command>
 ```
 
-`./Thelia` is a small shim that boots Symfony Runtime and the `Thelia\Core\Application` (wrapping `App\Kernel`, or `KernelInstall` when Thelia is not installed yet). Symfony's own built-in commands (for example `lint:twig`, `debug:router`, `debug:event-dispatcher`) are available through the standard console:
+`./Thelia` is a small shim that boots Symfony Runtime and the `Thelia\Core\Application` (wrapping `App\Kernel`, or `KernelInstall` when Thelia is not installed yet). Symfony's own built-in commands (for example `lint:twig`, `debug:router`, `debug:event-dispatcher`) are registered on that same application, so they run through `php Thelia` as well.
 
-```shell
-php bin/console <command>
-```
+:::note There is no `bin/console`
+The `thelia/thelia` repository ships no `bin/console`. Projects created with `composer create-project thelia/thelia-project` do ship one, but it only requires the very same `Thelia` shim. Use `php Thelia <command>`: it works in every layout.
+:::
 
 :::tip
 List every available command and its description with `php Thelia list`. Add `--help` to any command (`php Thelia module:list --help`) to see its arguments and options.
@@ -48,7 +48,8 @@ All commands below live in `Thelia\Command\` (core: `core/lib/Thelia/Command/`).
 | `image-cache:clear` | Empty part or all of the web-space image cache. |
 
 :::note
-`php Thelia cache:clear` purges the Thelia caches more completely than `php bin/console cache:clear`. Prefer the Thelia variant when in doubt.
+`cache:clear` empties the Symfony cache; `image-cache:clear` empties the images generated in the web
+space. Clearing one does not clear the other.
 :::
 
 ### Installation and database

--- a/versioned_docs/version-3.0/architecture/dual-templating.md
+++ b/versioned_docs/version-3.0/architecture/dual-templating.md
@@ -149,8 +149,8 @@ ddev exec php bin/install \
   --with-demo --with-admin
 
 # already installed: switch active back-office template
-ddev exec bin/console template:set backOffice default-twig
-ddev exec bin/console cache:warmup -e dev
+ddev exec php Thelia template:set backOffice default-twig
+ddev exec php Thelia cache:warmup -e dev
 
 # build assets
 ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"

--- a/versioned_docs/version-3.0/back-office/bundle-structure.md
+++ b/versioned_docs/version-3.0/back-office/bundle-structure.md
@@ -55,7 +55,7 @@ when it is the active admin template. `isActive()` compares its own name against
 
 Both `loadExtension()` and `prependExtension()` early-return when `isActive()` is `false`. The
 back-office you select with `bin/install --backoffice_theme=default-twig` (or
-`bin/console template:set backOffice default-twig`) is the only one whose services enter the
+`php Thelia template:set backOffice default-twig`) is the only one whose services enter the
 container.
 
 :::tip

--- a/versioned_docs/version-3.0/back-office/components.md
+++ b/versioned_docs/version-3.0/back-office/components.md
@@ -270,7 +270,7 @@ ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
 :::caution Rebuild after editing assets
 A SCSS or controller change is only visible after an Encore rebuild
 (`npm run build` or a running `npm run watch`). After editing a Twig template,
-clear the cache: `ddev exec bin/console cache:clear -e dev`.
+clear the cache: `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Learn more

--- a/versioned_docs/version-3.0/back-office/index.md
+++ b/versioned_docs/version-3.0/back-office/index.md
@@ -44,8 +44,8 @@ ddev exec php bin/install \
   --admin_email=thelia@example.com
 
 # already installed - switch the active back-office template
-ddev exec bin/console template:set backOffice default-twig
-ddev exec bin/console cache:warmup -e dev
+ddev exec php Thelia template:set backOffice default-twig
+ddev exec php Thelia cache:warmup -e dev
 
 # build the bundle assets (SCSS + JS)
 ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
@@ -56,7 +56,7 @@ The admin is then available at `https://<your-site>.ddev.site/admin`.
 :::tip Watch assets during development
 While editing SCSS or Stimulus controllers, run `npm run watch` from
 `templates/backOffice/default-twig/` so the bundle assets rebuild automatically. After editing a
-Twig template, clear the cache with `ddev exec bin/console cache:clear -e dev`.
+Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Bundle structure

--- a/versioned_docs/version-3.0/reference/cli/index.md
+++ b/versioned_docs/version-3.0/reference/cli/index.md
@@ -11,11 +11,11 @@ Thelia ships a console application built on the [Symfony Console component](http
 php Thelia <command>
 ```
 
-`./Thelia` is a small shim that boots Symfony Runtime and the `Thelia\Core\Application` (wrapping `App\Kernel`, or `KernelInstall` when Thelia is not installed yet). Symfony's own built-in commands (for example `lint:twig`, `debug:router`, `debug:event-dispatcher`) are available through the standard console:
+`./Thelia` is a small shim that boots Symfony Runtime and the `Thelia\Core\Application` (wrapping `App\Kernel`, or `KernelInstall` when Thelia is not installed yet). Symfony's own built-in commands (for example `lint:twig`, `debug:router`, `debug:event-dispatcher`) are registered on that same application, so they run through `php Thelia` as well.
 
-```shell
-php bin/console <command>
-```
+:::note There is no `bin/console`
+The `thelia/thelia` repository ships no `bin/console`. Projects created with `composer create-project thelia/thelia-project` do ship one, but it only requires the very same `Thelia` shim. Use `php Thelia <command>`: it works in every layout.
+:::
 
 :::tip
 List every available command and its description with `php Thelia list`. Add `--help` to any command (`php Thelia module:list --help`) to see its arguments and options.
@@ -48,7 +48,8 @@ All commands below live in `Thelia\Command\` (core: `core/lib/Thelia/Command/`).
 | `image-cache:clear` | Empty part or all of the web-space image cache. |
 
 :::note
-`php Thelia cache:clear` purges the Thelia caches more completely than `php bin/console cache:clear`. Prefer the Thelia variant when in doubt.
+`cache:clear` empties the Symfony cache; `image-cache:clear` empties the images generated in the web
+space. Clearing one does not clear the other.
 :::
 
 ### Installation and database


### PR DESCRIPTION
The documentation prescribed `bin/console` in several places. That file does not exist in the `thelia/thelia` repository: the CLI entry point is the `Thelia` shim at the project root, so every documented command failed there.

`composer create-project thelia/thelia-project` does ship a `bin/console`, but it only requires the same `vendor/thelia/core/Thelia` shim, so both entry points run the same application. `php Thelia <command>` is therefore correct in every layout, and Symfony's built-in commands (`lint:twig`, `debug:router`, `cache:warmup`, `template:set`) are registered on that application too.

Changes (mirrored in `docs/` and `versioned_docs/version-3.0/`):

- `reference/cli/index.md`: drop the `php bin/console <command>` block, add a note explaining the two layouts, and remove the claim that `php Thelia cache:clear` purges more than `php bin/console cache:clear` (same command).
- `architecture/dual-templating.md`, `back-office/index.md`, `back-office/components.md`: `ddev exec bin/console` -> `ddev exec php Thelia`.
- `back-office/bundle-structure.md`: same in prose.

https://claude.ai/code/session_0149T6CS2gt6ZUYhzkCCgK5L