### PR TITLE
Align the Flexy documentation on the current theme

### DIFF
--- a/docs/architecture/dual-templating.md
+++ b/docs/architecture/dual-templating.md
@@ -29,7 +29,7 @@ Both Twig themes are Symfony bundles: their templates, components, Stimulus cont
 
 ## Front-office: Twig + Symfony UX
 
-The front-office ships as the `FlexyBundle`. Templates live at the theme root, components and PHP under `src/`.
+The front-office ships as the `FlexyBundle`. Page templates live at the theme root, components under `components/`, and the rest of the PHP under `src/`.
 
 ### Template location
 
@@ -40,10 +40,10 @@ templates/frontOffice/flexy/
 ├── product.html.twig         # product page
 ├── category.html.twig        # category page
 ├── checkout-cart.html.twig   # cart step
+├── components/               # TwigComponent / LiveComponent (namespace @Flexy)
 └── src/
-    ├── Twig/
-    │   └── DataAccessExtension.php   # registers resources() and attr()
-    └── UiComponents/         # TwigComponent / LiveComponent
+    └── Twig/
+        └── DataAccessExtension.php   # registers resources() and attr()
 ```
 
 ### Data retrieval
@@ -90,27 +90,24 @@ Read a value derived from the current route with the `attr()` Twig function (als
 
 ### Components
 
-Flexy ships TwigComponents (server-rendered) and LiveComponents (reactive, re-render on the server without a page reload). Render them with the `component()` function, using the names declared in the `#[AsTwigComponent]` / `#[AsLiveComponent]` attributes under `src/UiComponents/`:
+Flexy ships TwigComponents (server-rendered) and LiveComponents (reactive, re-render on the server without a page reload). Both live under `components/`, and both are rendered with the `<twig:...>` tag syntax:
 
 ```twig
-{# Product page LiveComponent - receives the product array #}
-{{ component('Flexy:Pages:Product', { product: product }) }}
+{# Product details LiveComponent - receives the product array #}
+<twig:Layouts:ProductDetails:Base :product="product" />
 
 {# Category listing with filters (LiveComponent) #}
-{{ component('Flexy:CategoryFilters', {
-    initialCategoryId: categoryId,
-    initialPage: page
-}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="page" />
 
 {# Cart step (LiveComponent) #}
-{{ component('Flexy:Checkout:Cart') }}
+<twig:Organisms:Cart:Base />
 
 {# Order summary (LiveComponent) #}
-{{ component('Flexy:Checkout:Summary') }}
+<twig:Organisms:Summary:Checkout />
 ```
 
 :::tip
-Component names are namespaced with colons (`Flexy:Checkout:Cart`), mirroring their folder under `src/UiComponents/`. Grep the bundle for `AsLiveComponent` / `AsTwigComponent` to discover the available components and their props.
+A component is named after its class path under `FlexyBundle\Components\`, with `\` written as `:` and no prefix: `components/Organisms/Cart/Base.php` is `Organisms:Cart:Base`. The `#[AsTwigComponent]` and `#[AsLiveComponent]` attributes carry no `name:` argument. Browse `components/` to discover what is available and read each class for its props.
 :::
 
 See [LiveComponents](../front-office/live-components.md) for building your own.

--- a/docs/back-office/index.md
+++ b/docs/back-office/index.md
@@ -77,9 +77,9 @@ templates/backOffice/default-twig/
 │   └── _delete_modal.html.twig
 ├── components/                # reusable Twig component templates (DataTable, Dashboard, ...)
 ├── form/
-│   └── bo_form_theme.html.twig    # Bootstrap 5 form theme, scoped to /admin
+│   └── bo_form_theme.html.twig    # Bootstrap 5 form theme, opted into per form
 ├── config/
-│   └── packages/twig.yaml         # registers the form theme namespace + form_themes
+│   └── packages/twig.yaml         # form theme namespace + the bo_form_themes global
 ├── assets/                    # SCSS + JS + img + flags
 │   ├── app.js
 │   ├── controllers/           # Stimulus controllers
@@ -152,8 +152,8 @@ Symfony 7 removed Doctrine annotations. Always use the PHP 8 attribute
 ## Back-office forms
 
 Build admin forms with Symfony's form component and let the bundle's `bo_form_theme.html.twig`
-render them with Bootstrap 5 markup. The theme is registered globally and scopes itself to the
-`/admin` path, so any form rendered under `/admin` gets the back-office styling automatically.
+render them with Bootstrap 5 markup. The theme is not global: a template opts into it with
+`{% form_theme form with bo_form_themes only %}`, which also keeps the front-office widgets out.
 
 ```php
 // local/modules/MyModule/src/Form/ConfigType.php
@@ -185,6 +185,8 @@ Render the form in a Twig template with the standard Symfony form helpers:
 
 ```twig
 {# local/modules/MyModule/templates/config.html.twig #}
+{% form_theme form with bo_form_themes only %}
+
 {{ form_start(form, { action: path('mymodule.admin.config.save'), method: 'post' }) }}
     {{ form_row(form.apiKey) }}
     {{ form_row(form.enabled) }}
@@ -192,15 +194,17 @@ Render the form in a Twig template with the standard Symfony form helpers:
 {{ form_end(form) }}
 ```
 
-The form theme is wired in the bundle's Twig configuration:
+The list the tag refers to is a Twig global declared in the bundle's Twig configuration:
 
 ```yaml
 # templates/backOffice/default-twig/config/packages/twig.yaml
 twig:
   paths:
     "%kernel.project_dir%/templates/backOffice/default-twig/form": BackOfficeDefaultTwigForm
-  form_themes:
-    - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
+  globals:
+    bo_form_themes:
+      - "bootstrap_5_layout.html.twig"
+      - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
 ```
 
 ## Extending the back-office with hooks

--- a/docs/back-office/templates-form-theme.md
+++ b/docs/back-office/templates-form-theme.md
@@ -126,41 +126,36 @@ Use it whenever a partial exposes block slots like `_page_header.html.twig` does
 
 ## The form theme
 
-`bo_form_theme.html.twig` is a custom Bootstrap 5 Symfony form theme. It is registered
-globally under its own `@BackOfficeDefaultTwigForm` namespace in
-`config/packages/twig.yaml`, which the bundle imports during `prependExtension()`:
+`bo_form_theme.html.twig` is a custom Bootstrap 5 Symfony form theme. It is **not** registered
+globally: neither theme is. Each side declares its own list as a Twig global, and each template
+that renders a form opts in. The back-office list is declared in `config/packages/twig.yaml`,
+which the bundle imports during `prependExtension()`:
 
 ```yaml
 # templates/backOffice/default-twig/config/packages/twig.yaml
 twig:
   paths:
     "%kernel.project_dir%/templates/backOffice/default-twig/form": BackOfficeDefaultTwigForm
-  form_themes:
-    - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
+  globals:
+    bo_form_themes:
+      - "bootstrap_5_layout.html.twig"
+      - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
 ```
 
-Because `form_themes` applies to every form rendered by the active Twig environment,
-including front-office Flexy templates, each block in `bo_form_theme.html.twig` is scoped
-to admin requests. It applies the Bootstrap 5 markup only when the request path starts with
-`/admin`, and otherwise defers to the Flexy front-office theme:
+`bootstrap_5_layout.html.twig` comes first, so it supplies the complete Bootstrap base, and
+`bo_form_theme.html.twig` only carries the admin refinements on top. Render a form with:
 
 ```twig
-{# templates/backOffice/default-twig/form/bo_form_theme.html.twig #}
-{%- block form_widget_simple -%}
-    {%- if app is defined and app.request and app.request.pathInfo starts with '/admin' -%}
-        {{- block('form_widget_simple', 'bootstrap_5_layout.html.twig') -}}
-    {%- else -%}
-        {{- block('form_widget_simple', '@formTwig/flexy_form_theme.html.twig') -}}
-    {%- endif -%}
-{%- endblock form_widget_simple -%}
+{% form_theme form with bo_form_themes only %}
 ```
 
-:::caution Mirror every Flexy-overridden block
-The Flexy front-office theme overrides several widgets (`password`, `textarea`, `money`,
-`percent`, `choice`, `radio`, `range`, `file`, `submit`). The back-office theme must mirror
-all of them with the same `/admin` short-circuit. Otherwise a back-office form picks up a
-Flexy wrapper. For example, the `<div data-controller="password">` wrapper breaks the
-Bootstrap input-group layout on the login form.
+The `only` keyword excludes every other theme, so an admin form can never pick up a front-office
+Flexy widget. The isolation is structural: no block has to test the request path.
+
+:::caution Every admin form needs the tag
+Without `{% form_theme form with bo_form_themes only %}`, the form renders with Symfony's default
+markup instead of the Bootstrap 5 admin widgets. Put the tag in the block that renders the form,
+before `form_start`.
 :::
 
 ## Forms are standard Symfony forms
@@ -213,11 +208,14 @@ final class BrandType extends AbstractType
 }
 ```
 
-In the template, render the form with `form_start` / `form_end`. The `bo_form_theme`
-supplies the Bootstrap 5 markup, so you only point each widget at the right field:
+In the template, opt into the admin form theme, then render the form with `form_start` /
+`form_end`. The theme supplies the Bootstrap 5 markup, so you only point each widget at the
+right field:
 
 ```twig
 {# @BackOfficeDefaultTwig/catalog/brand/edit.html.twig #}
+{% form_theme form with bo_form_themes only %}
+
 {{ form_start(form, {
     action: path('admin.brand.save', { brand_id: brand.id }),
     method: 'post',

--- a/docs/front-office/data-access.md
+++ b/docs/front-office/data-access.md
@@ -319,15 +319,15 @@ final readonly class ProductService
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\CategoryFilters;
+namespace FlexyBundle\Components\Layouts\ProductListing;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Thelia\Api\Service\DataAccess\DataAccessService;
 
-#[AsLiveComponent(name: 'Flexy:CategoryFilters')]
-class CategoryFilters
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -494,7 +494,7 @@ if ($product === null) {
 {% endfor %}
 
 {# Good - fetch all at once if possible, or use component #}
-{{ component('Flexy:ProductCard', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 ```
 
 ### Use pagination

--- a/docs/front-office/flexy-theme/creating-theme.md
+++ b/docs/front-office/flexy-theme/creating-theme.md
@@ -19,7 +19,18 @@ the guide below follows it.
 
 ## A theme is a bundle
 
-The Flexy theme registers itself as a Symfony bundle. The whole theme (services, Twig components, Live components, controllers) is autowired from the bundle's `src/` directory.
+The Flexy theme registers itself as a Symfony bundle. Services and controllers are autowired from `src/`, components from `components/`, and both directories are declared as PSR-4 roots in the theme's `composer.json`:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "FlexyBundle\\": "src/",
+            "FlexyBundle\\Components\\": "components/"
+        }
+    }
+}
+```
 
 ```php
 // templates/frontOffice/flexy/src/FlexyBundle.php
@@ -28,52 +39,51 @@ namespace FlexyBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
-use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Model\ConfigQuery;
 
 class FlexyBundle extends AbstractBundle
 {
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $serviceConfigurator = $container->services();
+        $container->import('../config/services.yaml');
 
-        $resourcePath = $this->getResourcePath();
-        if (is_dir($resourcePath)) {
-            $serviceConfigurator->load('FlexyBundle\\', $resourcePath)
-                ->autowire()
-                ->autoconfigure();
-        }
-
-        $serviceConfigurator->load('FlexyBundle\\UiComponents\\', $this->getUiComponentsPath())
+        $container->services()
+            ->defaults()
             ->autowire()
             ->autoconfigure();
     }
 
     public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        if (!is_dir($this->getResourcePath())) {
-            return;
-        }
-        $container->import('../config/packages/*.yaml');
-    }
+        $builder->prependExtensionConfig('twig', [
+            'paths' => [
+                \dirname(__DIR__).'/components' => 'Flexy',
+                \dirname(__DIR__).'/form' => 'FlexyForm',
+            ],
+            'globals' => [
+                'flexy_form_themes' => ['@FlexyForm/flexy_form_theme.html.twig'],
+            ],
+        ]);
 
-    private function getResourcePath(): string
-    {
-        return THELIA_TEMPLATE_DIR.TemplateDefinition::FRONT_OFFICE_SUBDIR.DS.ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME, 'default').DS.'src';
-    }
+        $builder->prependExtensionConfig('twig_component', [
+            'anonymous_template_directory' => 'frontOffice/%thelia_front_template%/components/',
+            'defaults' => [
+                'FlexyBundle\\Components\\' => [
+                    'template_directory' => '@Flexy',
+                    'name_prefix' => '',
+                ],
+            ],
+        ]);
 
-    private function getUiComponentsPath(): string
-    {
-        return THELIA_TEMPLATE_DIR.TemplateDefinition::FRONT_OFFICE_SUBDIR.DS.ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME, 'default').DS.'src'.DS.'UiComponents';
+        // AssetMapper, UX Icons, Tailwind and Stimulus are configured the same way.
     }
 }
 ```
 
 What this does:
 
-- `loadExtension()` registers every class under `FlexyBundle\` (the bundle's `src/`) and `FlexyBundle\UiComponents\` as autowired, autoconfigured services. `autoconfigure()` is what makes `#[Route]` controllers, `#[AsTwigComponent]` and `#[AsLiveComponent]` classes work without any XML.
-- `prependExtension()` imports the theme's own `config/packages/*.yaml` so the theme can ship its own framework configuration.
-- The resource path is resolved at runtime from the *active* front-office template (the `default` config key), so the bundle always points at the theme currently selected in the back office.
+- `loadExtension()` imports `config/services.yaml`, which registers both PSR-4 roots as autowired, autoconfigured services. `autoconfigure()` is what makes `#[Route]` controllers, `#[AsTwigComponent]` and `#[AsLiveComponent]` classes work without any XML.
+- `prependExtension()` configures the framework for the theme: Twig namespaces and globals, the TwigComponent defaults, AssetMapper, UX Icons, Tailwind and the Stimulus controller paths. `name_prefix: ''` is what makes component names carry no prefix.
+- Keys that must follow the *active* front-office template are written with the `%thelia_front_template%` parameter, so a theme that is installed but not active does not register its own paths.
 
 The bundle is enabled in `config/bundles.php`:
 
@@ -86,12 +96,12 @@ return [
 ```
 
 :::note
-For your own theme, create a `MyThemeBundle` class following this pattern (adjust the namespace and the `psr-4` autoload entry in `composer.json`), register it in `config/bundles.php`, and point its resource paths at your theme directory. Without a Bundle class, controllers, Twig components and Live components in your theme will never be discovered.
+For your own theme, create a `MyThemeBundle` class following this pattern (adjust the namespaces and the two `psr-4` entries in `composer.json`), register it in `config/bundles.php`, and point its Twig and component paths at your theme directory. Without a Bundle class, controllers, Twig components and Live components in your theme will never be discovered.
 :::
 
 ## Directory structure
 
-The Flexy theme lives in `templates/frontOffice/flexy/`. A theme combines flat page templates at the root, a `src/` PHP tree (the bundle code) and an `assets/` pipeline:
+The Flexy theme lives in `templates/frontOffice/flexy/`. A theme combines flat page templates at the root, a `components/` tree, a `src/` PHP tree (the bundle code) and an `assets/` pipeline:
 
 ```
 templates/frontOffice/my-theme/
@@ -129,17 +139,17 @@ templates/frontOffice/my-theme/
 ├── 404.html.twig
 ├── error.html.twig
 ├── maintenance.html.twig
-├── components/                # Twig partials (Atomic Design)
+├── components/                # Components, PHP-backed or anonymous (namespace @Flexy)
 │   ├── Atoms/
-│   ├── Layout/
+│   ├── Fields/
+│   ├── Forms/
+│   ├── Layouts/
 │   ├── Molecules/
-│   ├── Organisms/
-│   └── Page/
-├── form/                      # Form theme(s)
-├── src/                       # The bundle: Bundle class, Controllers, UiComponents
+│   └── Organisms/
+├── form/                      # Form theme (namespace @FlexyForm)
+├── src/                       # The bundle: Bundle class, Controllers, Services, DTOs
 │   ├── MyThemeBundle.php
-│   ├── Controller/
-│   └── UiComponents/          # TwigComponents and LiveComponents (PHP + .html.twig)
+│   └── Controller/
 └── assets/
     ├── app.js
     ├── controllers.json
@@ -197,7 +207,7 @@ The tags, in order:
   tag: it would point at a `dist` directory no build ever produces.
 
 :::caution
-There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required_version>` tag. The descriptor does not declare theme inheritance. To reuse Flexy from your own theme, render Flexy's components directly (`{{ component('Flexy:...') }}`, see [Using Flexy components](#using-flexy-components)) rather than declaring a parent.
+There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required_version>` tag. The descriptor does not declare theme inheritance. To reuse Flexy from your own theme, render Flexy's components directly (see [Using Flexy components](#using-flexy-components)) rather than declaring a parent.
 :::
 
 ## Creating the base layout
@@ -223,7 +233,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
 
 <body class="{% block body_class %}{% endblock %}">
     {% block header %}
-        {{ include('@components/Layout/Header/Header.html.twig') }}
+        <twig:Layouts:Header:Base />
     {% endblock %}
 
     <main {% block main_attributes %}{% endblock %}>
@@ -231,7 +241,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
     </main>
 
     {% block footer %}
-        {{ include('@components/Layout/Footer/Footer.html.twig') }}
+        <twig:Layouts:Footer:Base />
     {% endblock %}
 
     {% block body_js %}{% endblock %}
@@ -243,7 +253,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
 `app` entrypoint declared in the theme's `importmap.php`. Both come from AssetMapper.
 
 :::note
-`@components` is a Twig namespace the theme registers in `config/packages/twig.yaml`, pointing at the theme's `components/` directory (Flexy also registers `@UiComponents` for `src/UiComponents` and `@assets` for `assets`). Always reference partials through the namespace (`@components/Layout/...`) as Flexy does, rather than a bare relative path.
+Flexy registers exactly two Twig namespaces from its bundle class: `@Flexy` for `components/` and `@FlexyForm` for `form/`. Components are usually rendered by name (`<twig:Layouts:Header:Base />`), and the namespace is used when one component template references another (`{% extends '@Flexy/Organisms/AddressCard/Base.html.twig' %}`).
 :::
 
 ## Essential pages
@@ -286,9 +296,7 @@ The homepage is served at `/` by the route named `index`. Fetch data with `resou
 
         <div class="product-grid">
             {% for product in products %}
-                {{ include('@components/Molecules/ProductCard/ProductCard.html.twig', {
-                    product: product
-                }) }}
+                <twig:Molecules:ProductCard:Base :product="product" />
             {% endfor %}
         </div>
     </section>
@@ -320,13 +328,13 @@ The current category id is read from the request attributes with `attr()`. The t
         </header>
 
         {# Delegate product listing + filters + pagination to a LiveComponent #}
-        {{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
+        <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
     </div>
 {% endblock %}
 ```
 
 :::tip
-Filtering, sorting and paginating a product grid is stateful work. Flexy delegates it to the `Flexy:CategoryFilters` LiveComponent rather than rebuilding pagination by hand in the template. See [LiveComponents](/docs/front-office/live-components).
+Filtering, sorting and paginating a product grid is stateful work. Flexy delegates it to the `Layouts:ProductListing:Base` LiveComponent rather than rebuilding pagination by hand in the template. See [LiveComponents](/docs/front-office/live-components).
 :::
 
 ### Product page (product.html.twig)
@@ -347,7 +355,7 @@ Filtering, sorting and paginating a product grid is stateful work. Flexy delegat
         <h1>{{ product.i18ns.title }}</h1>
 
         {# The add-to-cart UI (price, PSE selection, quantity) is a LiveComponent #}
-        {{ component('Flexy:Pages:Product', {product: product}) }}
+        <twig:Layouts:ProductDetails:Base :product="product" />
 
         {% if product.i18ns.description %}
             <section class="product-description">
@@ -360,20 +368,24 @@ Filtering, sorting and paginating a product grid is stateful work. Flexy delegat
 ```
 
 :::caution
-Adding to the cart is handled by the `Flexy:Pages:Product` LiveComponent, not by a plain HTML `<form>` posting to a `cart_add` route. No such route exists. If you build your own add-to-cart UI, model it on the Flexy Live component in `src/UiComponents/Pages/Product/`.
+Adding to the cart is handled by the `Layouts:ProductDetails:Base` LiveComponent, not by a plain HTML `<form>` posting to a `cart_add` route. No such route exists. If you build your own add-to-cart UI, model it on the Flexy Live component in `components/Layouts/ProductDetails/`.
 :::
 
 ## Creating components
 
 Flexy splits its UI in two places:
 
-- `components/` holds plain Twig partials organized with Atomic Design (`Atoms/`, `Molecules/`, `Organisms/`, `Layout/`, `Page/`). You `include` them through the `@components` namespace.
-- `src/UiComponents/` holds TwigComponents and LiveComponents: a PHP class plus its `.html.twig` template, rendered by name with `{{ component('Flexy:...') }}`. Flexy's own product card is one of these: `Flexy:ProductCard` (`src/UiComponents/ProductCard/`), which fetches its own price and image data.
+Everything lives in `components/`, organized with Atomic Design (`Atoms/`, `Molecules/`, `Organisms/`, `Layouts/`, `Fields/`, `Forms/`). A component is a directory:
 
-For a custom theme you can either reuse `Flexy:ProductCard` or build your own partial. The hand-built version below links to the product with `product.publicUrl` and resolves the image the same way the real Flexy `ProductCard` component does:
+- an anonymous component is a `.html.twig` file on its own;
+- a PHP-backed one adds a class next to its template, carrying a bare `#[AsTwigComponent]` or `#[AsLiveComponent]`.
+
+Either way the component is named after its path: `components/Organisms/ProductCard/Base.php` is rendered as `<twig:Organisms:ProductCard:Base />`. Flexy's own product card is one of these, and it fetches its own price and image data.
+
+For a custom theme you can either reuse `Organisms:ProductCard:Base` or build your own. The hand-built version below links to the product with `product.publicUrl` and resolves the image the same way the real one does:
 
 ```twig
-{# templates/frontOffice/my-theme/components/Molecules/ProductCard/ProductCard.html.twig #}
+{# templates/frontOffice/my-theme/components/Molecules/ProductCard/Base.html.twig #}
 <article class="product-card">
     <a href="{{ product.publicUrl }}">
         <div class="product-card-image">
@@ -401,7 +413,7 @@ For a custom theme you can either reuse `Flexy:ProductCard` or build your own pa
 The header links to real, named routes (the back-office and the Flexy controllers register them via `#[Route]` attributes):
 
 ```twig
-{# templates/frontOffice/my-theme/components/Layout/Header/Header.html.twig #}
+{# templates/frontOffice/my-theme/components/Layouts/Header/Base.html.twig #}
 <header class="site-header">
     <div class="container">
         {# Homepage route is named "index" #}
@@ -427,8 +439,8 @@ The header links to real, named routes (the back-office and the Flexy controller
                 <a href="{{ path('customer_login') }}">Login</a>
             {% endif %}
 
-            {# Cart link. Flexy renders this with its Flexy:HeaderButton TwigComponent,
-               which requires at least `text` (and usually `href`, `icon`). #}
+            {# Cart link. Flexy renders this with its Molecules:HeaderButton:Base
+               TwigComponent, which takes `text` and usually `href` and `icon`. #}
             <a href="{{ path('checkout_cart') }}" class="cart-link">Cart</a>
         </div>
     </div>
@@ -595,9 +607,9 @@ A custom theme can reuse Flexy's components instead of declaring inheritance in 
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    {{ component('Flexy:Pages:Product', {product: product}) }}
-    {{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
-    {{ component('Flexy:HeaderButton', {href: path('checkout_cart'), icon: 'cart', text: 'Cart'|trans}) }}
+    <twig:Layouts:ProductDetails:Base :product="product" />
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
+    <twig:Molecules:HeaderButton:Base href="{{ path('checkout_cart') }}" icon="cart" text="{{ 'Cart'|trans }}" />
 {% endblock %}
 ```
 

--- a/docs/front-office/flexy-theme/customization.md
+++ b/docs/front-office/flexy-theme/customization.md
@@ -54,34 +54,49 @@ Or pass it to the installer when you (re)install:
 php Thelia thelia:install --frontoffice_theme=myCustomTheme
 ```
 
-:::caution Namespace and component-prefix collisions
+:::caution Namespace and component-name collisions
 Flexy registers three project-global identifiers:
 
 - the Composer package name `thelia/flexy` (`composer.json`)
-- the PSR-4 namespace root `FlexyBundle\` (`composer.json`, `autoload.psr-4`)
-- the Twig component name prefix `Flexy` (`config/packages/twig_component.yaml`, under `FlexyBundle\UiComponents\`)
+- the PSR-4 roots `FlexyBundle\` (on `src/`) and `FlexyBundle\Components\` (on `components/`)
+- the Twig namespaces `@Flexy` and `@FlexyForm`
 
-If you install your copy alongside the original Flexy, both register `FlexyBundle\` and the `Flexy:` Twig component prefix. Symfony will load one class definition over the other, and component names like `Flexy:ProductCard` become ambiguous.
+Component names carry no prefix at all: Flexy sets `name_prefix: ''`, so a component is named after
+its class path under `FlexyBundle\Components\`. `Organisms:ProductCard:Base` is one name in the
+project, whichever theme declares it.
+
+If you install your copy alongside the original Flexy, both register the same PSR-4 roots, the same
+Twig namespaces and the same component names. Symfony loads one class definition over the other.
 
 To run both side by side, rename them in your copy:
 
-1. In `composer.json`, change the package `name` and the `autoload.psr-4` root (for example `MyThemeBundle\`).
-2. Rename the `FlexyBundle\` namespace in every PHP file under `src/` to your new root.
-3. In `config/packages/twig_component.yaml`, change the `name_prefix` and the namespace key:
+1. In `composer.json`, change the package `name` and both `autoload.psr-4` roots (for example `MyThemeBundle\` and `MyThemeBundle\Components\`).
+2. Rename the `FlexyBundle\` namespace in every PHP file under `src/` and `components/`.
+3. In your bundle class, change the Twig namespaces and the `twig_component` defaults key:
 
-```yaml
-# templates/frontOffice/myCustomTheme/config/packages/twig_component.yaml
-twig_component:
-    anonymous_template_directory: 'frontOffice/%thelia_front_template%/components/'
-    defaults:
-        MyThemeBundle\UiComponents\:
-            name_prefix: MyTheme
-            template_directory: '%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/src/UiComponents'
+```php
+// templates/frontOffice/myCustomTheme/src/MyThemeBundle.php
+$builder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'MyTheme',
+        \dirname(__DIR__).'/form' => 'MyThemeForm',
+    ],
+]);
+
+$builder->prependExtensionConfig('twig_component', [
+    'anonymous_template_directory' => 'frontOffice/%thelia_front_template%/components/',
+    'defaults' => [
+        'MyThemeBundle\\Components\\' => [
+            'template_directory' => '@MyTheme',
+            'name_prefix' => 'MyTheme',
+        ],
+    ],
+]);
 ```
 
-4. Update every `{{ component('Flexy:...') }}` call in your templates to the new prefix.
+4. Update the component calls in your templates to the prefix you chose (`<twig:MyTheme:Organisms:ProductCard:Base />`).
 
-If you only need one active front-office theme (the common case), you do not have to rename anything: keep `FlexyBundle\` and `Flexy:`, and do not require the upstream `thelia/flexy` package at the same time.
+If you only need one active front-office theme (the common case), you do not have to rename anything: keep the Flexy identifiers, and do not require the upstream `thelia/flexy` package at the same time.
 :::
 
 ## Customization strategies
@@ -97,33 +112,20 @@ If you only need one active front-office theme (the common case), you do not hav
 
 ### Tailwind configuration
 
-Flexy's `tailwind.config.js` scans the bundle's own files. The real `content` globs are relative to the theme directory:
+Tailwind v4 is CSS-first: there is no `tailwind.config.js`. `assets/styles/app.css` is the
+configuration, and it lists the directories Tailwind scans with `@source`. They are spelled out
+because the theme directory is git-ignored from the project root, which makes Tailwind's automatic
+source detection skip it:
 
-```javascript
-// templates/frontOffice/myCustomTheme/tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    content: [
-        './components/**/*.{twig,ts,js,json}',
-        './src/UiComponents/**/*.{twig,ts,js,json}',
-        './form/**/*.twig',
-        './*.twig',
-    ],
-    theme: {
-        extend: {
-            colors: {
-                // Flexy maps Tailwind colors to CSS variables.
-                // Override the variables in your CSS (see below), or add new colors here.
-                'brand': {
-                    50: '#f0f9ff',
-                    500: '#0ea5e9',
-                    700: '#0369a1',
-                },
-            },
-        },
-    },
-    plugins: [],
-};
+```css
+/* templates/frontOffice/myCustomTheme/assets/styles/app.css */
+@import "tailwindcss";
+
+@source "../../components";
+@source "../../partials";
+@source "../../*.html.twig";
+@source "../../form";
+@source "../../blocks";
 ```
 
 :::note
@@ -132,10 +134,11 @@ Flexy's default theme colors (`theme`, `theme-dark`, `grey`, `error`, ...) are d
 
 ### Custom CSS
 
-Edit the theme stylesheets under `templates/frontOffice/myCustomTheme/assets/css/`.
+Edit the theme stylesheets under `templates/frontOffice/myCustomTheme/assets/styles/`. Component CSS
+lives next to the component it styles, and `app.css` imports it.
 
 ```css
-/* templates/frontOffice/myCustomTheme/assets/css/app.css */
+/* templates/frontOffice/myCustomTheme/assets/styles/variables.css */
 
 /* Override Flexy theme variables */
 :root {
@@ -190,21 +193,23 @@ templates/frontOffice/myCustomTheme/
 ├── index.html.twig           # Homepage
 ├── product.html.twig         # Product page
 ├── category.html.twig        # Category page
-├── components/               # Anonymous Twig components (atoms / molecules / organisms)
-│   ├── Layout/
+├── components/               # Every component, PHP-backed or anonymous (namespace @Flexy)
+│   ├── Layouts/
 │   │   ├── Header/
-│   │   │   └── Header.html.twig
+│   │   │   ├── Base.php
+│   │   │   └── Base.html.twig
 │   │   └── Footer/
+│   ├── Molecules/
 │   └── Organisms/
-│       └── CategoryCard/
-│           └── CategoryCard.html.twig
-└── src/
-    └── UiComponents/         # Twig / Live components (PHP + template)
-        ├── ProductCard/
-        ├── CrossSelling/
-        └── Pages/
-            └── Product/
+│       └── ProductCard/
+│           ├── Base.php
+│           ├── Base.css
+│           └── Base.html.twig
+└── src/                      # Bundle class, controllers, DTOs, services
 ```
+
+A component is a directory holding its PHP class, its Twig template, its CSS and, when it needs one,
+its Stimulus controller. Anonymous components (no PHP class) sit in the same tree, template only.
 
 ### Modify page templates
 
@@ -222,7 +227,7 @@ templates/frontOffice/myCustomTheme/
         </div>
 
         <div class="product-info">
-            {{ component('Flexy:Pages:Product', {product: product}) }}
+            <twig:Layouts:ProductDetails:Base :product="product" />
         </div>
 
         {# Custom sections #}
@@ -242,7 +247,7 @@ templates/frontOffice/myCustomTheme/
 Categories and products are linked through their rewritten URLs, not through route-name-with-id helpers. The API resource exposes a `publicUrl` field (`Category::getPublicUrl()`, `Product::getPublicUrl()`, serialized in the `front:*:read` group). The homepage route is named `index`.
 
 ```twig
-{# templates/frontOffice/myCustomTheme/components/Layout/Header/Header.html.twig #}
+{# templates/frontOffice/myCustomTheme/components/Layouts/Header/Base.html.twig #}
 <header class="site-header">
     <div class="container">
         {# Logo points to the homepage #}
@@ -268,63 +273,67 @@ Categories and products are linked through their rewritten URLs, not through rou
         </nav>
 
         {# Cart / account actions #}
-        {{ include('@components/Organisms/HeaderNav/HeaderNav.html.twig') }}
+        <twig:Organisms:HeaderNav:Base />
     </div>
 </header>
 ```
 
 :::caution Do not build catalog links from route + id
-There is no `product_show` or `category` route taking an `{id}`. Catalog pages are served from SEO-friendly rewritten URLs. Always render a category or product link from its `publicUrl` field. For a ready-made card, feed the resource to the `CategoryCard` organism, which reads `category.publicUrl` internally:
+There is no `product_show` or `category` route taking an `{id}`. Catalog pages are served from SEO-friendly rewritten URLs. Always render a category or product link from its `publicUrl` field. For a ready-made card, pass that URL to the `CategoryCard` organism:
 
 ```twig
-{{ include('@components/Organisms/CategoryCard/CategoryCard.html.twig', {
-    category: category,
-    id: category.id
-}) }}
+<twig:Organisms:CategoryCard:Base
+    id="{{ category.id }}"
+    title="{{ category.i18ns.title }}"
+    href="{{ category.publicUrl }}"
+/>
 ```
 :::
 
 ## Component customization
 
-Flexy ships two kinds of server-rendered components under `src/UiComponents/`:
+Flexy ships two kinds of server-rendered components under `components/`:
 
-- Twig components (`#[AsTwigComponent]`) are stateless and rendered once. Example: `ProductCard`, `CrossSelling`.
-- Live components (`#[AsLiveComponent]`) are reactive and can re-render on user interaction. Example: `Pages\Product`, `CategoryFilters`.
+- Twig components (`#[AsTwigComponent]`) are stateless and rendered once. Example: `Organisms:ProductCard:Base`, `Layouts:CrossSelling:Base`.
+- Live components (`#[AsLiveComponent]`) are reactive and can re-render on user interaction. Example: `Layouts:ProductDetails:Base`, `Layouts:ProductListing:Base`.
 
 ### Modify an existing component
 
-`ProductCard` is a Twig component. It accepts either a `productId` (it then fetches the product itself) or a `product` (a `ProductDTO` or a raw array). Here is its real signature:
+`Organisms:ProductCard:Base` is a Twig component. It accepts either a `productId` (it then fetches the product itself) or a `product` (a `ProductDTO` or a raw array). Here is its real signature:
 
 ```php
 <?php
-// templates/frontOffice/myCustomTheme/src/UiComponents/ProductCard/ProductCard.php
+// templates/frontOffice/myCustomTheme/components/Organisms/ProductCard/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\ProductCard;
+namespace FlexyBundle\Components\Organisms\ProductCard;
 
 use FlexyBundle\DTO\ProductDTO;
+use FlexyBundle\Service\ProductImageResolver;
+use FlexyBundle\Service\ProductTaxationResolver;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 use Thelia\Api\Service\DataAccess\DataAccessService;
-use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 
-#[AsTwigComponent(name: 'Flexy:ProductCard', template: '@UiComponents/ProductCard/ProductCard.html.twig')]
-class ProductCard
+#[AsTwigComponent]
+class Base extends AbstractProductCard
 {
     public ?int $productId = null;
 
     public function __construct(
-        private readonly DataAccessService $dataAccessService,
-        private TaxEngine $taxEngine,
+        DataAccessService $dataAccessService,
+        ProductImageResolver $productImageResolver,
+        private readonly ProductTaxationResolver $productTaxationResolver,
     ) {
+        parent::__construct($dataAccessService, $productImageResolver);
     }
 
     #[PreMount]
     public function preMount(?array $data): void
     {
         if (isset($data['productId']) && $data['productId']) {
-            $this->productId = $data['productId'];
+            $this->productId = (int) $data['productId'];
         }
     }
 
@@ -335,31 +344,33 @@ class ProductCard
 }
 ```
 
-To customize it, edit the file in your theme: add helper methods, change the price logic, or edit the template at `src/UiComponents/ProductCard/ProductCard.html.twig`.
+To customize it, edit the file in your theme: add helper methods, change the price logic, or edit the template next to it, `components/Organisms/ProductCard/Base.html.twig`.
 
 :::caution
-`ProductCard` is a Twig component (`#[AsTwigComponent]`), not a Live component, and its data property is a typed `ProductDTO` (resolved in `mount()`), not a public `array $product` LiveProp. If you need reactivity (a property writable from the browser that triggers a re-render), create a Live component instead.
+`Organisms:ProductCard:Base` is a Twig component (`#[AsTwigComponent]`), not a Live component, and its data property is a typed `ProductDTO` (resolved in `mount()`), not a public `array $product` LiveProp. If you need reactivity (a property writable from the browser that triggers a re-render), create a Live component instead.
 :::
 
 ### Add a new Live component
 
-Create reactive components under `src/UiComponents/`. The Twig component prefix is `Flexy` (from `twig_component.yaml`), and the template directory resolves to `src/UiComponents`:
+Create reactive components under `components/`. The attribute stays bare: Flexy sets `name_prefix: ''`
+and `template_directory: '@Flexy'`, so both the component name and its template are derived from the
+class path.
 
 ```php
 <?php
-// templates/frontOffice/myCustomTheme/src/UiComponents/Newsletter/Newsletter.php
+// templates/frontOffice/myCustomTheme/components/Organisms/Newsletter/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\Newsletter;
+namespace FlexyBundle\Components\Organisms\Newsletter;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent(name: 'Flexy:Newsletter', template: '@UiComponents/Newsletter/Newsletter.html.twig')]
-class Newsletter
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -377,6 +388,9 @@ class Newsletter
     }
 }
 ```
+
+Its template is `components/Organisms/Newsletter/Base.html.twig`, and it renders as
+`<twig:Organisms:Newsletter:Base />`.
 
 See [Live Components](/docs/front-office/live-components) for the full reference.
 
@@ -430,12 +444,12 @@ See [Stimulus](/docs/front-office/stimulus) for more.
 
 ### Related products
 
-Use the `Flexy:ProductCard` Twig component to render a grid of products. To exclude the current product, use the `not_in` filter exposed by the API resource.
+Use the `Organisms:ProductCard:Base` Twig component to render a grid of products. To exclude the current product, use the `not_in` filter exposed by the API resource.
 
 ```twig
 {# product.html.twig #}
 {% block body %}
-    {{ component('Flexy:Pages:Product', {product: product}) }}
+    <twig:Layouts:ProductDetails:Base :product="product" />
 
     {# Related products in the same category #}
     <section class="related-products">
@@ -447,7 +461,7 @@ Use the `Flexy:ProductCard` Twig component to render a grid of products. To excl
         }) %}
         <div class="product-grid">
             {% for p in related %}
-                {{ component('Flexy:ProductCard', {product: p}) }}
+                <twig:Organisms:ProductCard:Base :product="p" />
             {% endfor %}
         </div>
     </section>
@@ -455,26 +469,41 @@ Use the `Flexy:ProductCard` Twig component to render a grid of products. To excl
 ```
 
 :::caution NotInFilter syntax
-The Thelia `NotInFilter` is keyed `not_in[<property>]` and expects an array of values, for example `'not_in[id]': [product.id]`. This matches the core `Flexy:CrossSelling` component, which queries `'not_in[id]' => $this->productIdsToIgnore`. The reverse form `id[not_in]` is not supported and will be ignored.
+The Thelia `NotInFilter` is keyed `not_in[<property>]` and expects an array of values, for example `'not_in[id]': [product.id]`. This matches the `Layouts:CrossSelling:Base` component, which queries `'not_in[id]' => $this->productIdsToIgnore`. The reverse form `id[not_in]` is not supported and will be ignored.
 :::
 
-`Flexy:ProductCard` accepts a `product` (a `ProductDTO` or a raw array), both handled by its `mount()` method, or a `productId` if you only have the id.
+`Organisms:ProductCard:Base` accepts a `product` (a `ProductDTO` or a raw array), both handled by its `mount()` method, or a `productId` if you only have the id.
 
 ## Form customization
 
-Flexy ships a form theme at `form/flexy_form_theme.html.twig`. To customize form rendering in your theme, edit that file (or create your own and register it). It overrides the standard Symfony form blocks:
+Flexy ships a form theme at `form/flexy_form_theme.html.twig`, reached as `@FlexyForm/flexy_form_theme.html.twig`. Each of its blocks delegates the markup to an anonymous component under `components/Fields/`, so restyling an input usually means editing the component rather than the theme:
 
 ```twig
 {# templates/frontOffice/myCustomTheme/form/flexy_form_theme.html.twig #}
 {% use 'form_div_layout.html.twig' %}
 
-{% block form_row %}
-    <div class="form-group {{ errors|length ? 'has-error' : '' }}">
-        {{ form_label(form) }}
-        {{ form_widget(form) }}
-        {{ form_errors(form) }}
-    </div>
-{% endblock %}
+{# The widget components render their own label and error, so the row adds no wrapper #}
+{%- block form_row -%}
+    {{- form_widget(form) -}}
+{%- endblock form_row -%}
+
+{%- block form_widget_simple -%}
+    {{ component('Fields:Input:Base', {
+        label: label,
+        name: full_name,
+        id: id,
+        type: type|default('text'),
+        value: value,
+        error: errors|first.message|default(false),
+        required: required,
+    }) }}
+{%- endblock form_widget_simple -%}
+```
+
+Templates apply the theme explicitly, one form at a time:
+
+```twig
+{% form_theme form with flexy_form_themes only %}
 ```
 
 See [Forms](/docs/front-office/forms) for the front-office form workflow.

--- a/docs/front-office/flexy-theme/index.md
+++ b/docs/front-office/flexy-theme/index.md
@@ -12,7 +12,7 @@ Flexy is the default front-office theme for Thelia 3. It is a Symfony bundle (`F
 Flexy provides:
 
 - A UI styled with Tailwind CSS
-- Around 50 components (25 LiveComponents + 24 TwigComponents), all auto-discovered from `src/UiComponents/`
+- 88 PHP-backed components (21 LiveComponents + 67 TwigComponents) plus a set of anonymous ones, all auto-discovered from `components/`
 - A full e-commerce flow (catalog, cart, checkout, account)
 - Server-rendered reactivity through Symfony UX LiveComponents and Stimulus
 - The routes that serve the front office, including the catch-all that renders catalog pages
@@ -26,7 +26,7 @@ The whole theme is a single Composer package of type `thelia-frontoffice-templat
 
 ```
 templates/frontOffice/flexy/
-├── composer.json              # type: thelia-frontoffice-template, autoload FlexyBundle\ → src/
+├── composer.json              # type: thelia-frontoffice-template, two PSR-4 roots
 ├── src/                       # PHP classes (PSR-4: FlexyBundle\)
 │   ├── FlexyBundle.php        # the bundle entry point
 │   ├── Controller/
@@ -35,13 +35,7 @@ templates/frontOffice/flexy/
 │   ├── EventListener/
 │   ├── Form/
 │   ├── Service/
-│   ├── Twig/
-│   └── UiComponents/          # Live & Twig Components (PHP + colocated .html.twig)
-│       ├── Pages/Product/
-│       ├── Checkout/
-│       ├── CategoryFilters/
-│       ├── CrossSelling/
-│       └── ...
+│   └── Twig/
 ├── base.html.twig             # base layout
 ├── index.html.twig            # homepage
 ├── category.html.twig         # category listing
@@ -49,46 +43,64 @@ templates/frontOffice/flexy/
 ├── checkout-*.html.twig       # checkout steps
 ├── account*.html.twig         # customer account
 ├── login.html.twig            # login page
-├── components/                # anonymous Twig components (Atoms / Molecules / Organisms / Layout)
-├── form/                      # form theme + custom field templates
+├── components/                # every component (PSR-4: FlexyBundle\Components\, namespace @Flexy)
+│   ├── Atoms/
+│   ├── Fields/
+│   ├── Forms/
+│   ├── Layouts/
+│   ├── Molecules/
+│   ├── Organisms/
+│   └── Toolkit/
+├── form/                      # form theme (namespace @FlexyForm)
 │   └── flexy_form_theme.html.twig
 ├── config/
 │   ├── views.yaml             # root templates that are not pages of their own
-│   └── packages/              # bundle config imported by the theme
+│   └── packages/              # third-party bundle config the theme ships
 ├── assets/                    # styles, icons, images, Stimulus controllers
 └── importmap.php              # AssetMapper entrypoints and JavaScript dependencies
 ```
 
 :::note
-There is no `vendor/thelia/flexy/src/` versus `templates/frontOffice/flexy/` split. The bundle is one directory. The `FlexyBundle\` namespace maps to `src/`, declared in the theme's own `composer.json`.
+There is no `vendor/thelia/flexy/src/` versus `templates/frontOffice/flexy/` split. The bundle is one directory. Its `composer.json` declares two PSR-4 roots: `FlexyBundle\` on `src/` and `FlexyBundle\Components\` on `components/`.
 :::
 
 ### How the bundle wires itself
 
-`FlexyBundle` extends Symfony's `AbstractBundle`. It loads its services with autowiring and autoconfiguration, and imports its own configuration:
+`FlexyBundle` extends Symfony's `AbstractBundle`. It loads its services from its own
+`config/services.yaml`, which registers both PSR-4 roots with autowiring and autoconfiguration:
 
 ```php
 // templates/frontOffice/flexy/src/FlexyBundle.php
 public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
 {
-    $serviceConfigurator = $container->services();
+    $container->import('../config/services.yaml');
 
-    $serviceConfigurator->load('FlexyBundle\\', $this->getResourcePath())
+    $container->services()
+        ->defaults()
         ->autowire()
         ->autoconfigure();
-
-    $serviceConfigurator->load('FlexyBundle\\UiComponents\\', $this->getUiComponentsPath())
-        ->autowire()
-        ->autoconfigure();
-}
-
-public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
-{
-    $container->import('../config/packages/*.yaml');
 }
 ```
 
-No XML. Services, components, Twig paths and the form theme are all declared through PHP attributes and the bundle's `config/packages/*.yaml`.
+Almost everything else is configured from `prependExtension()`, in PHP rather than YAML: the Twig
+paths and globals, the TwigComponent defaults, AssetMapper, UX Icons, Tailwind and the Stimulus
+controller paths. The theme's own `config/packages/` holds only third-party bundle configuration.
+
+```php
+public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+{
+    $this->prependConfigTwig($builder);
+    $this->prependConfigTwigComponent($builder);
+    $this->prependConfigAssetMapper($builder);
+    $this->prependConfigUxIcons($builder);
+    $this->prependConfigTailwind($builder);
+    $this->prependConfigStimulus($builder);
+    $this->prependConfigPackages($container);
+}
+```
+
+No XML. Services, components, Twig namespaces and the form theme are all declared through PHP
+attributes and this bundle class.
 
 ## Key pages
 
@@ -99,18 +111,22 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    {{ component('Flexy:CrossSelling', {categoryId: 1, title: 'Last seen products'|trans}) }}
+    {{ theme_hook('home.top') }}
 
-    <div class="bg-theme-lighter">
-        {{ component('Flexy:CrossSelling', {categoryId: 2, title: 'Popular products'|trans}) }}
+    <twig:Layouts:CrossSelling:Base categoryId="3" title="{{ 'Last seen products'|trans }}" />
+
+    <div class="bg-lighter">
+        <twig:Layouts:CrossSelling:Base categoryId="5" title="{{ 'Popular products'|trans }}" />
     </div>
 
-    {{ component('Flexy:ProductCategory', {title: 'Our product categories'|trans}) }}
+    <twig:Layouts:ProductCategory:Base title="{{ 'Our product categories'|trans }}" />
+
+    {{ theme_hook('home.bottom') }}
 {% endblock %}
 ```
 
-:::caution
-`Flexy:CrossSelling` requires a `categoryId`. There is no default in the PHP class, so calling it without one throws an error. See [Cross-selling](#cross-selling) below.
+:::tip
+`Layouts:CrossSelling:Base` browses one category, or the whole catalog when `categoryId` is left out. See [Cross-selling](#cross-selling) below.
 :::
 
 ### Category page (`category.html.twig`)
@@ -119,21 +135,23 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {# templates/frontOffice/flexy/category.html.twig #}
 {% extends 'base.html.twig' %}
 
-{% set categoryId = attr('category', 'id') %}
-{% set category = resources('/api/front/categories/' ~ categoryId) %}
-
 {% block body %}
-    {# Category hero #}
-    {{ component('Flexy:CatHero', {
-        title: category.i18ns.title,
-        chapo: category.i18ns.chapo,
-        breadcrumb: breadcrumb
-    }) }}
+    {% set categoryId = attr('category', 'id') %}
+    {% set category = resources('/api/front/categories/' ~ categoryId) %}
+
+    {{ theme_hook('category.top', {category: category}) }}
+
+    {# Category heading #}
+    <twig:Layouts:Subheader:Category
+        title="{{ SEOnePageH1()|default(null) ?: attr('category', 'title') }}"
+        description="{{ attr('category', 'chapo') }}"
+        :breadcrumb="breadcrumb"
+    />
 
     {# Reactive product listing with filters #}
-    {{ component('Flexy:CategoryFilters', {
-        initialCategoryId: categoryId
-    }) }}
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
+
+    {{ theme_hook('category.bottom', {category: category}) }}
 {% endblock %}
 ```
 
@@ -143,153 +161,187 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {# templates/frontOffice/flexy/product.html.twig #}
 {% extends 'base.html.twig' %}
 
-{% set productId = attr('product', 'id') %}
-{% set product = resources('/api/front/products/' ~ productId) %}
-
 {% block body %}
-    <div class="ProductPage container">
+    {% set productId = attr('product', 'id') %}
+    {% set product = resources('/api/front/products/' ~ productId) %}
+
+    {{ theme_hook('product.top', {product: product}) }}
+
+    <div class="ProductPage">
         {# Breadcrumb #}
-        {{ component('Molecules:Breadcrumb:Breadcrumb', {breadcrumb: breadcrumb}) }}
+        <twig:Molecules:Breadcrumb:Base :items="breadcrumb" />
 
         {# Main product component (variant selection, add to cart) #}
-        {{ component('Flexy:Pages:Product', {product: product}) }}
+        <twig:Layouts:ProductDetails:Base :product="product" />
 
-        {# Cross-selling: categoryId is required #}
-        {{ component('Flexy:CrossSelling', {
-            categoryId: product.productCategories|first.category.id,
-            title: 'Last seen products'|trans
-        }) }}
+        {# Cross-selling in the category the product is filed under #}
+        <twig:Layouts:CrossSelling:Base
+            :categoryId="product.productCategories|first.category.id"
+            title="{{ 'Last seen products'|trans }}"
+        />
     </div>
 
     {# Add to cart toast notification #}
-    {{ component('Flexy:AddToCartToast') }}
+    <twig:Organisms:AddToCartToast:Base />
 {% endblock %}
 ```
 
 ## Components
 
-Flexy ships around 50 components in `src/UiComponents/`. The directory is the authoritative list: each PHP class carries either an `#[AsLiveComponent]` or an `#[AsTwigComponent]` attribute, and the component name is whatever that attribute declares.
+Flexy ships 88 PHP-backed components in `components/`, alongside a set of anonymous ones that are template-only. The directory is the authoritative list: each PHP class carries either an `#[AsLiveComponent]` or an `#[AsTwigComponent]` attribute.
 
 - LiveComponents (`#[AsLiveComponent]`) re-render on the server in response to user interaction (model binding, live actions). Use them for forms, filters and checkout steps.
 - TwigComponents (`#[AsTwigComponent]`) are stateless and render once. Use them for cards, layout pieces and presentational widgets.
 
-All names are prefixed with `Flexy` (configured in `config/packages/twig_component.yaml`). Call any component with the `component()` Twig function.
+### How a component is named
+
+The attributes are written bare, with no `name:` and no `template:` argument. The bundle sets
+`name_prefix: ''` and `template_directory: '@Flexy'`, so both are derived from the class path under
+`FlexyBundle\Components\`:
+
+```php
+// templates/frontOffice/flexy/components/Organisms/ProductCard/Base.php
+namespace FlexyBundle\Components\Organisms\ProductCard;
+
+#[AsTwigComponent]
+class Base { /* ... */ }
+```
+
+That class is the component `Organisms:ProductCard:Base`, its template is
+`components/Organisms/ProductCard/Base.html.twig`, and it renders as:
+
+```twig
+<twig:Organisms:ProductCard:Base :product="product" />
+```
+
+There is no `Flexy:` prefix. A component that carried one would be named `Flexy:...` only because a
+theme chose that prefix; Flexy itself does not.
 
 ### LiveComponents
 
 | Component | Purpose |
 |-----------|---------|
-| `Flexy:Pages:Product` | Full product page (variant selection, add to cart) |
-| `Flexy:CategoryFilters` | Product listing with reactive filters |
-| `Flexy:SearchBar` | Search with autocomplete |
-| `Flexy:Checkout:Cart` | Shopping cart |
-| `Flexy:Checkout:Payment` | Payment method selection |
-| `Flexy:Checkout:Summary` | Order summary |
-| `Flexy:Checkout:MiniSummary` | Compact order summary |
-| `Flexy:Checkout:Gateway` | Payment gateway step |
-| `Flexy:Checkout:Invoice` | Invoice address step |
-| `Flexy:Checkout:NextButton` | Checkout next-step button |
-| `Flexy:Checkout:PickupPointSearch` | Pickup point search (checkout) |
-| `Flexy:Checkout:PromoCodeForm` | Promo code input |
-| `Flexy:Checkout:Delivery` | Delivery step (delivery module selection) |
-| `Flexy:Checkout:Delivery:HomeDelivery` | Home delivery option |
-| `Flexy:Checkout:Delivery:PickupDelivery` | Pickup delivery option |
-| `Flexy:AccountAddressForm` | Account address form |
-| `Flexy:AccountCustomerUpdate` | Profile edit form |
-| `Flexy:AddressesForm` | Address form |
-| `Flexy:AddToCartToast` | Add-to-cart notification |
-| `Flexy:CustomerInformationForm` | Customer information form |
-| `Flexy:InvoiceAddresses` | Invoice address selection |
-| `Flexy:OrderCreator` | Order creation flow |
-| `Flexy:PaymentModules` | Payment module selection |
-| `Flexy:PickupPointSearch` | Pickup point search |
-| `Flexy:RegisterValidationCode` | Registration validation code |
+| `Layouts:ProductDetails:Base` | Product detail block (variant selection, add to cart) |
+| `Layouts:ProductListing:Base` | Product listing with reactive filters |
+| `Organisms:SearchBar:Base` | Search with autocomplete |
+| `Organisms:Cart:Base` | Shopping cart |
+| `Organisms:CartButton:Base` | Cart button with count |
+| `Organisms:Payment:Base` | Payment method selection |
+| `Organisms:Summary:Checkout` | Order summary |
+| `Organisms:Summary:Mini` | Compact order summary |
+| `Organisms:Invoice:Base` | Invoice address step |
+| `Organisms:NextButton:Base` | Checkout next-step button |
+| `Organisms:Delivery:Base` | Delivery step (delivery module selection) |
+| `Organisms:DeliveryMode:Home` | Home delivery option |
+| `Organisms:DeliveryMode:Pickup` | Pickup delivery option |
+| `Organisms:AddToCartToast:Base` | Add-to-cart notification |
+| `Forms:Address:Base` | Address form |
+| `Forms:Address:Account` | Address form in the customer account |
+| `Forms:Customer:Update` | Profile edit form |
+| `Forms:CustomerInformation:Base` | Customer information form |
+| `Forms:PickupSearch:Base` | Pickup point search |
+| `Forms:PromoCode:Base` | Promo code input |
+| `Forms:RegisterValidationCode:Base` | Registration validation code |
 
 ### TwigComponents
 
+The 67 Twig components are grouped the same way. The ones a theme reuses most often:
+
 | Component | Purpose |
 |-----------|---------|
-| `Flexy:ProductCard` | Product card in listings |
-| `Flexy:CrossSelling` | Related products carousel |
-| `Flexy:CartItem` | Single cart item |
-| `Flexy:HeaderButton` | Cart icon with count |
-| `Flexy:HeaderProfile` | User menu |
-| `Flexy:LangSelect` | Language switcher |
-| `Flexy:Blocks` | CMS blocks |
-| `Flexy:AccountHero` | Account header |
-| `Flexy:AddressCard` | Address display |
-| `Flexy:OrderCard` | Order history item |
-| `Flexy:OrderProductCard` | Order line product card |
-| `Flexy:CatHero` | Category hero |
-| `Flexy:Button` | Button |
-| `Flexy:CheckboxButton` | Checkbox button |
-| `Flexy:RadioButton` | Radio button |
-| `Flexy:InvoiceCard` | Invoice card |
-| `Flexy:PaymentCard` | Payment method card |
-| `Flexy:DeliveryTracking` | Delivery tracking display |
-| `Flexy:ProductCategory` | Product category block |
-| `Flexy:SimilarContent` | Similar content block |
-| `Flexy:Inputs:Radio` | Radio input |
-| `Flexy:Checkout:CheckoutSteps` | Checkout step indicator |
-| `Flexy:Checkout:AddressCardCheckout` | Address card in checkout |
-| `Flexy:Checkout:Delivery:StoreDelivery` | Store delivery option |
+| `Organisms:ProductCard:Base` | Product card in listings |
+| `Organisms:ProductCard:Search` | Product card in search results |
+| `Organisms:ProductCard:Order` | Product card in an order |
+| `Layouts:CrossSelling:Base` | Related products strip |
+| `Layouts:ProductCategory:Base` | Category grid block |
+| `Layouts:Header:Base` | Site header |
+| `Layouts:Footer:Base` | Site footer |
+| `Organisms:CartItem:Base` | Single cart item |
+| `Organisms:CategoryCard:Base` | Category card |
+| `Organisms:HeaderProfile:Base` | User menu |
+| `Organisms:LangSelect:Base` | Language switcher |
+| `Organisms:Blocks:Base` | CMS blocks |
+| `Organisms:AddressCard:Base` | Address display |
+| `Organisms:OrderCard:Base` | Order history item |
+| `Organisms:InvoiceCard:Base` | Invoice card |
+| `Organisms:PaymentCard:Base` | Payment method card |
+| `Organisms:DeliveryTracking:Base` | Delivery tracking display |
+| `Organisms:ProductGallery:Base` | Product image gallery |
+| `Molecules:Breadcrumb:Base` | Breadcrumb |
+| `Molecules:Button:Base` | Button |
+| `Molecules:Pagination:Base` | Pagination |
+| `Molecules:CheckoutSteps:Base` | Checkout step indicator |
+| `Molecules:Modal:Base` | Modal |
+| `Molecules:HeaderButton:Base` | Header icon button |
 
 :::note
-Watch the exact namespaces: the step indicator is `Flexy:Checkout:CheckoutSteps` (not `Flexy:CheckoutSteps`), and the promo form is `Flexy:Checkout:PromoCodeForm` (not `Flexy:PromoCodeForm`). When in doubt, open the component's PHP class in `src/UiComponents/` and read the `name:` argument of its attribute.
+Read the directory, not this table: `components/` is the source of truth, and the name of a component is its path under it. `components/Fields/` holds anonymous components (`Fields:Input:Base`, `Fields:Select:Base`, ...) that the form theme renders; they have no PHP class.
 :::
 
 ### Cross-selling
 
-`Flexy:CrossSelling` is a TwigComponent. Its PHP class exposes exactly two PHP properties:
+`Layouts:CrossSelling:Base` is a TwigComponent:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/CrossSelling/CrossSelling.php
-#[AsTwigComponent(name: 'Flexy:CrossSelling', template: '@UiComponents/CrossSelling/CrossSelling.html.twig')]
-class CrossSelling
-{
-    public string $categoryId;          // required, no default
-    public array $productIdsToIgnore = [];
+// templates/frontOffice/flexy/components/Layouts/CrossSelling/Base.php
+namespace FlexyBundle\Components\Layouts\CrossSelling;
 
-    // getProducts() fetches /api/front/products filtered by category,
-    // capped at 3 items, excluding $productIdsToIgnore
+#[AsTwigComponent]
+class Base
+{
+    private const DEFAULT_ITEMS_PER_PAGE = 4;
+
+    public int|string|null $categoryId = null;
+    public int $itemsPerPage = self::DEFAULT_ITEMS_PER_PAGE;
+
+    // mount() fetches visible products from /api/front/products, filtered by
+    // category when categoryId is set, and preloads their images and taxed prices
 }
 ```
 
 ```twig
-{# Fetch the 3 newest products of category 5, excluding the current one #}
-{{ component('Flexy:CrossSelling', {
-    categoryId: 5,
-    productIdsToIgnore: [currentProductId],
-    title: 'You may also like'|trans
-}) }}
+{# The 4 newest products of category 5 #}
+<twig:Layouts:CrossSelling:Base
+    categoryId="5"
+    title="{{ 'You may also like'|trans }}"
+/>
 ```
 
-:::caution
-`categoryId` is required. There is no `limit` property: the component always returns up to 3 products. `title` is a presentational prop read by the template, not by the PHP class.
+:::note
+`categoryId` is optional: without it the strip browses the whole catalog. `itemsPerPage` defaults to 4. `title` is a presentational prop read by the template, not by the PHP class.
 :::
 
 ### Using components
 
+The tag syntax is what the theme uses everywhere:
+
 ```twig
 {# A stateless TwigComponent #}
-{{ component('Flexy:ProductCard', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 
 {# A reactive LiveComponent #}
-{{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" />
 ```
 
-Anonymous components under `components/` are rendered with `include()` using the `@components` namespace:
+The `component()` function takes the same names, and is handy where a tag will not do, for instance when the name is computed:
 
 ```twig
-{{ include('@components/Layout/Header/Header.html.twig') }}
-{{ include('@components/Molecules/Breadcrumb/Breadcrumb.html.twig', {breadcrumb: breadcrumb}) }}
+{{ component('Molecules:FilterList:Base', {filters: filters}) }}
+```
+
+Component templates reference each other through the `@Flexy` namespace:
+
+```twig
+{% extends '@Flexy/Organisms/AddressCard/Base.html.twig' %}
+{{ include('@Flexy/Molecules/Pagination/Base.html.twig', pagination) }}
 ```
 
 ## Styling
 
 ### Tailwind CSS
 
-Flexy is styled with Tailwind CSS, configured in `tailwind.config.js`:
+Flexy is styled with Tailwind v4, which is CSS-first: the configuration is `assets/styles/app.css`,
+not a `tailwind.config.js`.
 
 ```twig
 <div class="container mx-auto px-4">
@@ -299,7 +351,7 @@ Flexy is styled with Tailwind CSS, configured in `tailwind.config.js`:
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         {% for product in products %}
-            {{ component('Flexy:ProductCard', {product: product}) }}
+            <twig:Organisms:ProductCard:Base :product="product" />
         {% endfor %}
     </div>
 </div>
@@ -465,43 +517,77 @@ renders the same on both PHP versions.
 
 ## Form theme
 
-Flexy ships a custom form theme at `form/flexy_form_theme.html.twig`. The `form/` directory is mapped to the `@formTwig` Twig namespace by the bundle's `config/packages/twig.yaml`, and the theme is applied globally in the same file:
-
-```yaml
-# templates/frontOffice/flexy/config/packages/twig.yaml
-twig:
-  paths:
-    "%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/form": formTwig
-  form_themes:
-    - "frontOffice/%thelia_front_template%/form/flexy_form_theme.html.twig"
-```
-
-Because the theme is registered globally, you usually do not need a per-form `{% form_theme %}` tag: every form rendered in the front office already uses it. To override it for a single form, reference the theme by its namespace:
+Flexy ships a custom form theme at `form/flexy_form_theme.html.twig`, reached through the
+`@FlexyForm` namespace. The theme is deliberately not registered globally, because a global form
+theme would also restyle the back office. Instead the bundle publishes the list as a Twig global,
+and each template that renders a form opts in:
 
 ```twig
-{% form_theme myForm '@formTwig/flexy_form_theme.html.twig' %}
-{{ form_widget(myForm) }}
+{% form_theme form with flexy_form_themes only %}
+{{ form_widget(form) }}
 ```
 
+Both the namespace and the global come from `FlexyBundle::prependExtension()`:
+
+```php
+// templates/frontOffice/flexy/src/FlexyBundle.php
+$containerBuilder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'Flexy',
+        \dirname(__DIR__).'/form' => 'FlexyForm',
+    ],
+    'globals' => [
+        'flexy_form_themes' => [
+            '@FlexyForm/flexy_form_theme.html.twig',
+        ],
+    ],
+]);
+```
+
+The form theme itself renders each widget through an anonymous component under `components/Fields/`,
+so restyling an input means editing that component rather than the theme file.
+
 :::caution
-The `@Flexy` Twig namespace does not exist in this bundle. Form-related templates use `@formTwig`, components use `@components` and `@UiComponents`.
+Forget the tag and the form falls back to Symfony's default markup. The `only` keyword matters too:
+it is what keeps the back-office widgets out of a front-office form.
 :::
 
 ## SEO features
 
-The base layout uses functions from the SEOne module to render titles, meta and structured data:
+The base layout does not render the title, the meta description, the canonical link, the hreflang
+tags or the breadcrumb JSON-LD itself. It opens a theme hook and lets a module answer:
 
 ```twig
 {# templates/frontOffice/flexy/base.html.twig (excerpt) #}
-<title>{{ SEOnePageTitle() }}</title>
-<meta name="description" content="{{ SEOnePageDesc() }}">
-<link rel="canonical" href="{{ SEOnePageCanonical() }}"/>
-{{ SEOneBreadcrumbJsonLd(breadcrumb)|raw }}
-{{ SEOneHreflang()|raw }}
+{{ theme_hook('layout.head.top', {
+    breadcrumb,
+    title:       block('title') is defined ? block('title')|trim : null,
+    description: block('meta_description') is defined ? block('meta_description')|trim : null,
+    og_type:     block('og_type') is defined ? block('og_type')|trim : null,
+}) }}
+
+{# ... #}
+
+{{ theme_hook('layout.head.bottom', {breadcrumb}) }}
 ```
 
+A page fills the `title`, `meta_description` and `og_type` blocks, and the hook receives whatever
+they contain. The SEOne module answers both head hooks and falls back to its own computed values for
+anything a page leaves unset. With no module answering, the head renders without those tags rather
+than breaking.
+
+The layout still emits what belongs to the theme: `og:image`, `og:locale`, `og:site_name`,
+`twitter:card`, the favicons and an empty `{% block robots %}` that pages such as the checkout fill
+with `noindex, follow`.
+
+Pages also call SEOne's Twig functions directly where the value is page-specific: `SEOneBreadcrumb()`
+in the layout, `SEOnePageH1()` on the product and category pages, `SEOneWebSite()` / `SEOneWebPage()`
+/ `SEOneLocalBusiness()` in the `structured_data` block of the homepage.
+
 :::note
-These functions are provided by the SEOne module (a Flexy dependency), not by Thelia core.
+`theme_hook()` is a core Thelia function, and a module answers it by implementing
+`Thelia\Core\Hook\Theme\ThemeHookInterface`. The `SEOne*` functions are provided by the SEOne module,
+not by the core. See [Theme hooks](/docs/front-office/theme-hooks) for writing your own handler.
 :::
 
 ## Installation

--- a/docs/front-office/forms.md
+++ b/docs/front-office/forms.md
@@ -47,11 +47,11 @@ Inject `Thelia\Core\Form\FormServiceInterface`. A no-op default implementation i
 
 ## A LiveComponent form
 
-The Flexy theme exposes its forms as LiveComponents. A good example is `AccountCustomerUpdate`, the "edit my profile" component:
+The Flexy theme exposes its forms as LiveComponents, grouped under `components/Forms/`. A good example is `Forms:Customer:Update`, the "edit my profile" component:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/AccountCustomerUpdate/AccountCustomerUpdate.php
-namespace FlexyBundle\UiComponents\AccountCustomerUpdate;
+// templates/frontOffice/flexy/components/Forms/Customer/Update.php
+namespace FlexyBundle\Components\Forms\Customer;
 
 use FlexyBundle\Form\CustomerUpdateForm;
 use Symfony\Component\Form\FormInterface;
@@ -59,14 +59,11 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
-use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\Form\FormServiceInterface;
+use Thelia\Domain\Customer\CustomerFacade;
 
-#[AsLiveComponent(
-    name: 'Flexy:AccountCustomerUpdate',
-    template: '@UiComponents/AccountCustomerUpdate/AccountCustomerUpdate.html.twig'
-)]
-class AccountCustomerUpdate extends BaseFrontController
+#[AsLiveComponent]
+class Update
 {
     use ComponentWithFormTrait;
     use DefaultActionTrait;
@@ -76,6 +73,7 @@ class AccountCustomerUpdate extends BaseFrontController
 
     public function __construct(
         private readonly FormServiceInterface $formService,
+        private readonly CustomerFacade $customerFacade,
     ) {
     }
 
@@ -88,23 +86,25 @@ class AccountCustomerUpdate extends BaseFrontController
 
 Three pieces make this a form component:
 
-- `#[AsLiveComponent]` registers it and binds it to a Twig template.
+- `#[AsLiveComponent]` registers it. It carries no argument: the component is named after its class path (`Forms:Customer:Update`) and its template is the `Update.html.twig` sitting next to it.
 - `ComponentWithFormTrait` wires the Symfony form lifecycle (rendering, hydration, submission) and requires you to implement `instantiateForm()`.
 - `DefaultActionTrait` provides the default re-render action triggered by LiveProp changes.
 
 `instantiateForm()` returns the form built by `$this->formService->getFormByName(...)`. Here the name comes from a Flexy form class constant (`CustomerUpdateForm::FORM_NAME`), but it can equally be a `FrontForm` constant.
 
-:::caution Prefer constructor injection over `extends BaseFrontController`
-Flexy components extend `Thelia\Controller\Front\BaseFrontController`. That base class exposes container helpers (a service-locator style). It is convenient, but it hides dependencies, so treat it as an anti-pattern. For your own components, prefer plain constructor injection of the exact services you need, as shown above with `FormServiceInterface`. Extending `BaseFrontController` is documented here only because it is what the current Flexy theme does.
+:::tip Inject, do not inherit
+A form component needs no base class. Inject the exact services you need, as above with
+`FormServiceInterface` and `CustomerFacade`. A few Flexy components extend Symfony's
+`AbstractController`, but only where they genuinely use its helpers.
 :::
 
 ## Handling submission with a LiveAction
 
-Add a `#[LiveAction]` method that calls `submitForm()` then checks validity. The `PromoCodeForm` checkout component shows the pattern:
+Add a `#[LiveAction]` method that calls `submitForm()` then checks validity. The `Forms:PromoCode:Base` component shows the pattern:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/Checkout/PromoCodeForm/PromoCodeForm.php
-namespace FlexyBundle\UiComponents\Checkout\PromoCodeForm;
+// templates/frontOffice/flexy/components/Forms/PromoCode/Base.php
+namespace FlexyBundle\Components\Forms\PromoCode;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
@@ -112,18 +112,14 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
-use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\Event\Coupon\CouponConsumeEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Form\FormServiceInterface;
 use Thelia\Domain\Cart\CartFacade;
 use Thelia\Form\CouponCode;
 
-#[AsLiveComponent(
-    name: 'Flexy:Checkout:PromoCodeForm',
-    template: '@UiComponents/Checkout/PromoCodeForm/PromoCodeForm.html.twig'
-)]
-class PromoCodeForm extends BaseFrontController
+#[AsLiveComponent]
+class Base
 {
     use ComponentWithFormTrait;
     use DefaultActionTrait;
@@ -177,7 +173,9 @@ public function save(): void
 ### Template
 
 ```twig
-{# templates/frontOffice/flexy/src/UiComponents/.../SomeForm.html.twig #}
+{# templates/frontOffice/flexy/components/Forms/SomeForm/Base.html.twig #}
+{% form_theme form with flexy_form_themes only %}
+
 <div {{ attributes }}>
     {{ form_start(form) }}
         {{ form_widget(form) }}
@@ -246,25 +244,44 @@ LiveComponents can validate fields as the user types, using `data-model` binding
 
 ## Flexy form theme
 
-The Flexy theme registers its form theme globally, so widgets are styled automatically. You do not need a `{% form_theme %}` tag in each template. This is configured in the bundle's `config/packages/twig.yaml`:
-
-```yaml
-# templates/frontOffice/flexy/config/packages/twig.yaml
-twig:
-  paths:
-    "%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/form": formTwig
-  form_themes:
-    - "frontOffice/%thelia_front_template%/form/flexy_form_theme.html.twig"
-```
-
-The `formTwig` Twig namespace points at the theme's `form/` directory, which is why partials reference the theme as `@formTwig/flexy_form_theme.html.twig`:
+Flexy ships its form theme at `@FlexyForm/flexy_form_theme.html.twig`. It is **not** registered as a
+global `twig.form_themes` entry: a global theme would also restyle the back-office forms. Instead the
+bundle exposes the list as a Twig global, and every template that renders a form opts in:
 
 ```twig
-{% use '@formTwig/flexy_form_theme.html.twig' %}
+{% form_theme form with flexy_form_themes only %}
 ```
 
-:::note
-Because the theme is applied via `form_themes` in `twig.yaml`, every front-office form is rendered with the Flexy widgets by default. Only add an explicit `{% form_theme form '@formTwig/flexy_form_theme.html.twig' %}` when you render a form in a context where the global theme does not apply.
+The `only` keyword keeps every other theme out, so the widgets rendered below are Flexy's and nothing
+else. Put the tag inside the block that renders the form, before `form_start`.
+
+The global and the `@FlexyForm` namespace are both declared by the bundle, in
+`FlexyBundle::prependExtension()`:
+
+```php
+// templates/frontOffice/flexy/src/FlexyBundle.php
+$containerBuilder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'Flexy',
+        \dirname(__DIR__).'/form' => 'FlexyForm',
+    ],
+    'globals' => [
+        'flexy_form_themes' => [
+            '@FlexyForm/flexy_form_theme.html.twig',
+        ],
+    ],
+]);
+```
+
+A field template that reuses the theme's blocks imports them by namespace:
+
+```twig
+{% use '@FlexyForm/flexy_form_theme.html.twig' %}
+```
+
+:::caution
+A front-office form rendered without the `{% form_theme %}` tag gets Symfony's bare default markup,
+not the Flexy widgets. The back office works the same way, with its own `bo_form_themes` global.
 :::
 
 ## Plain Symfony fallback
@@ -272,7 +289,7 @@ Because the theme is applied via `form_themes` in `twig.yaml`, every front-offic
 If you need a one-off form that has no Thelia definition, you can build it inline with Symfony's `createFormBuilder()`. This is standard Symfony, not the Thelia way. Prefer a named Thelia form whenever one exists:
 
 :::caution `createFormBuilder()` requires `AbstractController`
-`createFormBuilder()` is a helper provided by Symfony's `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`. Thelia's `BaseFrontController` (used by the components above) does not extend it, so the call below only works in a component that extends `AbstractController`, as the Flexy `CategoryFilters` component does. Otherwise, inject `Symfony\Component\Form\FormFactoryInterface` and call `$this->formFactory->createBuilder()`.
+`createFormBuilder()` is a helper provided by Symfony's `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`, so the call below only works in a component that extends it, as `Layouts:ProductListing:Base` does. Otherwise, inject `Symfony\Component\Form\FormFactoryInterface` and call `$this->formFactory->createBuilder()`.
 :::
 
 ```php

--- a/docs/front-office/index.md
+++ b/docs/front-office/index.md
@@ -44,7 +44,7 @@ Front-Office Request Flow
 │    │  → DataAccessService → API Platform → Propel        │      │
 │    └─────────────────────────────────────────────────────┘      │
 │    ┌─────────────────────────────────────────────────────┐      │
-│    │  {{ component('Flexy:ProductCard', {...}) }}        │      │
+│    │  <twig:Organisms:ProductCard:Base :product=... />   │      │
 │    │  → LiveComponent (reactive)                         │      │
 │    └─────────────────────────────────────────────────────┘      │
 └─────────────────────────────────────────────────────────────────┘
@@ -79,7 +79,7 @@ LiveComponents give you reactive UI without writing JavaScript:
 
 ```twig
 {# Render a reactive product component #}
-{{ component('Flexy:Pages:Product', {product: product}) }}
+<twig:Layouts:ProductDetails:Base :product="product" />
 ```
 
 The component automatically handles:
@@ -113,12 +113,14 @@ templates/frontOffice/flexy/
 ├── product.html.twig           # Product page template
 ├── checkout-*.html.twig        # Checkout page templates
 ├── account*.html.twig          # Customer account page templates
-├── components/                 # Anonymous Twig components
+├── components/                 # Every component, namespace @Flexy
 │   ├── Atoms/                  # Smallest UI primitives (Icon, Font, ...)
+│   ├── Fields/                 # Form field markup, rendered by the form theme
+│   ├── Forms/                  # Form components (LiveComponents)
+│   ├── Layouts/                # Header, Footer, listings, ...
 │   ├── Molecules/              # Reusable UI elements
 │   ├── Organisms/              # Complex components
-│   ├── Layout/                 # Header, Footer, Hero, ...
-│   └── Page/                   # Page-level building blocks
+│   └── Toolkit/                # Component showcase pages
 ├── src/                        # PHP code (autoconfigured by FlexyBundle)
 │   ├── Controller/             # Front-office controllers
 │   ├── DTO/                    # Data Transfer Objects
@@ -127,9 +129,8 @@ templates/frontOffice/flexy/
 │   ├── Form/                   # Symfony form types
 │   ├── Service/                # Services (DeliveryService, FormService, ...)
 │   ├── Twig/                   # Twig extensions (DataAccessExtension)
-│   ├── UiComponents/           # Twig/Live components (.php + colocated .html.twig)
 │   └── FlexyBundle.php         # Bundle class (loadExtension / prependExtension)
-├── form/                       # Form theme (flexy_form_theme.html.twig + fields/)
+├── form/                       # Form theme (flexy_form_theme.html.twig), namespace @FlexyForm
 ├── assets/                     # styles, icons, images
 │   └── controllers/            # Stimulus controllers
 ├── config/
@@ -140,7 +141,7 @@ templates/frontOffice/flexy/
 ```
 
 :::note Components: anonymous vs. PHP-backed
-`components/` holds anonymous Twig components (Atoms/Molecules/Organisms/Layout/Page): pure `.html.twig` files with no PHP class. `src/UiComponents/` holds PHP-backed TwigComponents and LiveComponents, where each one is a PHP class with a colocated `.html.twig` template in the same folder.
+Both kinds live in `components/`, side by side. An anonymous component is a `.html.twig` file on its own; a PHP-backed one adds a class next to its template, in the same folder. `FlexyBundle\Components\` maps to that directory, and a component's name is its path under it: `components/Organisms/ProductCard/Base.php` is `Organisms:ProductCard:Base`.
 :::
 
 ## Section contents
@@ -177,15 +178,12 @@ A minimal category page that uses all of these concepts together:
     <h1>{{ category.i18ns.title }}</h1>
 
     {# Use a LiveComponent for filtering #}
-    {{ component('Flexy:CategoryFilters', {
-        initialCategoryId: categoryId,
-        initialPage: 1
-    }) }}
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="1" />
 
     {# Or render products directly #}
     <div class="product-grid">
         {% for product in products %}
-            {{ component('Flexy:ProductCard', {product: product}) }}
+            <twig:Organisms:ProductCard:Base :product="product" />
         {% endfor %}
     </div>
 {% endblock %}

--- a/docs/front-office/live-components.md
+++ b/docs/front-office/live-components.md
@@ -21,46 +21,45 @@ For complete LiveComponents documentation, see [symfony.com/bundles/ux-live-comp
 ## Basic structure
 
 :::info TwigComponent vs LiveComponent
-The Flexy theme uses both kinds of component, roughly half and half: `#[AsTwigComponent]` for static, render-once UI (24 components, like `ProductCard`) and `#[AsLiveComponent]` for reactive, AJAX-powered UI (25 components, like `CategoryFilters`, `Pages:Product` and `Checkout:Cart`). Reach for a LiveComponent only when the UI must re-render after the initial load. See [Stimulus](./stimulus) and the [Flexy theme overview](./flexy-theme/) for the static side.
+The Flexy theme uses both kinds of component: `#[AsTwigComponent]` for static, render-once UI (67 components, like `Organisms:ProductCard:Base`) and `#[AsLiveComponent]` for reactive, AJAX-powered UI (21 components, like `Layouts:ProductListing:Base`, `Layouts:ProductDetails:Base` and `Organisms:Cart:Base`). Reach for a LiveComponent only when the UI must re-render after the initial load. See [Stimulus](./stimulus) and the [Flexy theme overview](./flexy-theme/) for the static side.
 :::
 
-Each component lives in its own folder, which holds both the PHP class and its Twig template:
+Each component lives in its own folder under `components/`, which holds the PHP class, its Twig template and, when it needs them, its CSS and Stimulus controller:
 
 ```
-templates/frontOffice/flexy/src/UiComponents/
-    CategoryFilters/
-        CategoryFilters.php
-        CategoryFilters.html.twig
-    Pages/Product/
-        Product.php
-        Product.html.twig
-    Checkout/Cart/
-        Cart.php
-        Cart.html.twig
+templates/frontOffice/flexy/components/
+    Layouts/ProductListing/
+        Base.php
+        Base.html.twig
+        Base.css
+        base_controller.js
+    Layouts/ProductDetails/
+        Base.php
+        Base.html.twig
+    Organisms/Cart/
+        Base.php
+        Base.html.twig
 ```
 
-The PHP namespace mirrors that folder layout (`FlexyBundle\UiComponents\<Path>`), and the `template:` option points at the same folder through the `@UiComponents` Twig namespace registered by Flexy.
+The PHP namespace mirrors that folder layout (`FlexyBundle\Components\<Path>`), and the attribute needs no argument: the bundle sets `name_prefix: ''` and `template_directory: '@Flexy'`, so the component name and its template are both derived from the class path. `FlexyBundle\Components\Layouts\ProductListing\Base` is the component `Layouts:ProductListing:Base`.
 
 ### PHP component
 
 ```php
 <?php
-// templates/frontOffice/flexy/src/UiComponents/CategoryFilters/CategoryFilters.php
+// templates/frontOffice/flexy/components/Layouts/ProductListing/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\CategoryFilters;
+namespace FlexyBundle\Components\Layouts\ProductListing;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent(
-    name: 'Flexy:CategoryFilters',
-    template: '@UiComponents/CategoryFilters/CategoryFilters.html.twig'
-)]
-class CategoryFilters
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -76,10 +75,15 @@ class CategoryFilters
 }
 ```
 
+:::caution Never pass `name:` or `template:` in this theme
+No component in Flexy does. Passing them would break the convention the whole theme relies on, and
+the name would no longer match the file the template sits next to.
+:::
+
 ### Twig template
 
 ```twig
-{# templates/frontOffice/flexy/src/UiComponents/CategoryFilters/CategoryFilters.html.twig #}
+{# templates/frontOffice/flexy/components/Layouts/ProductListing/Base.html.twig #}
 <div {{ attributes }}>
     <div class="product-grid">
         {% for product in products %}
@@ -99,7 +103,7 @@ LiveComponents need `{{ attributes }}` on the single root tag to wire up the AJA
 ### Usage
 
 ```twig
-{{ component('Flexy:CategoryFilters', {categoryId: categoryId, page: 1}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="1" />
 ```
 
 ## Key concepts
@@ -158,11 +162,11 @@ Use `ComponentWithFormTrait` to embed a Symfony Form. Build the Thelia form by n
 
 ```php
 <?php
-// templates/frontOffice/flexy/src/UiComponents/Pages/Product/Product.php
+// templates/frontOffice/flexy/components/Layouts/ProductDetails/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\Pages\Product;
+namespace FlexyBundle\Components\Layouts\ProductDetails;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -174,11 +178,8 @@ use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Thelia\Core\Form\FormServiceInterface;
 use Thelia\Form\Definition\FrontForm;
 
-#[AsLiveComponent(
-    name: 'Flexy:Pages:Product',
-    template: '@UiComponents/Pages/Product/Product.html.twig'
-)]
-class Product
+#[AsLiveComponent]
+class Base
 {
     use ComponentToolsTrait;
     use ComponentWithFormTrait;
@@ -225,17 +226,14 @@ LiveComponents talk to each other with `emit()` / `#[LiveListener]`. Flexy uses 
 
 ### Emitting events
 
-The product page (`Flexy:Pages:Product`) emits an `addToCart` event after adding the line to the cart:
+The product details component (`Layouts:ProductDetails:Base`) emits an `addToCart` event after adding the line to the cart:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/Pages/Product/Product.php
+// templates/frontOffice/flexy/components/Layouts/ProductDetails/Base.php
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 
-#[AsLiveComponent(
-    name: 'Flexy:Pages:Product',
-    template: '@UiComponents/Pages/Product/Product.html.twig'
-)]
-class Product
+#[AsLiveComponent]
+class Base
 {
     use ComponentToolsTrait;
 
@@ -253,18 +251,15 @@ class Product
 
 ### Listening to events
 
-A separate component, `Flexy:AddToCartToast`, listens for that event and refreshes itself to show the confirmation toast:
+A separate component, `Organisms:AddToCartToast:Base`, listens for that event and refreshes itself to show the confirmation toast:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/AddToCartToast/AddToCartToast.php
+// templates/frontOffice/flexy/components/Organisms/AddToCartToast/Base.php
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveListener;
 
-#[AsLiveComponent(
-    name: 'Flexy:AddToCartToast',
-    template: '@UiComponents/AddToCartToast/AddToCartToast.html.twig'
-)]
-class AddToCartToast
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -277,12 +272,12 @@ class AddToCartToast
 ```
 
 :::note Pick a unique event name
-The listener name must match the emitted name exactly (`'addToCart'` here). Flexy also uses constants for the checkout flow (see `FlexyBundle\UiComponents\Checkout\CheckoutEvents`) to avoid magic strings between many cooperating components.
+The listener name must match the emitted name exactly (`'addToCart'` here). Flexy also uses constants for the checkout flow (see `FlexyBundle\Event\CheckoutEvents`) to avoid magic strings between many cooperating components.
 :::
 
 ### Browser events
 
-To trigger client-side JavaScript (a [Stimulus](./stimulus) controller, for instance) rather than another component, dispatch a browser event. `Flexy:Pages:Product` does this when the selected product sale element changes:
+To trigger client-side JavaScript (a [Stimulus](./stimulus) controller, for instance) rather than another component, dispatch a browser event. `Layouts:ProductDetails:Base` does this when the selected product sale element changes:
 
 ```php
 $this->dispatchBrowserEvent('change:pse', ['pseId' => $this->currentPse['id']]);
@@ -391,13 +386,15 @@ A Thelia 3 module must declare its service namespace via the static `configureSe
 
 ### Option B: drop into the Flexy theme (simple, theme-coupled)
 
-If you only target the Flexy theme, place the component directly under the theme's `UiComponents` folder so it resolves through the existing `@UiComponents` namespace:
+If you only target the Flexy theme, place the component directly under the theme's `components/` folder so it resolves through the theme's own naming convention and the `@Flexy` namespace:
 
 ```
-templates/frontOffice/flexy/src/UiComponents/NewsletterForm/
-    NewsletterForm.php
-    NewsletterForm.html.twig
+templates/frontOffice/flexy/components/Organisms/NewsletterForm/
+    Base.php
+    Base.html.twig
 ```
+
+It is then rendered as `<twig:Organisms:NewsletterForm:Base />`, with a bare `#[AsLiveComponent]` and no `template:` argument.
 
 This is simpler but couples the component to the `flexy` theme. To override an existing Flexy template from a module instead, drop your file under `local/modules/MyModule/templates/frontOffice/flexy/`. The kernel scans that directory at boot and adds it after the active theme.
 

--- a/docs/front-office/stimulus.md
+++ b/docs/front-office/stimulus.md
@@ -97,7 +97,7 @@ Stimulus works alongside LiveComponents for client-side animations and effects:
 <div {{ attributes }}
      data-controller="animation"
      data-action="addToCart->animation#pulse">
-    {{ component('Flexy:ProductCard', {product: product}) }}
+    <twig:Organisms:ProductCard:Base :product="product" />
 </div>
 ```
 

--- a/docs/front-office/theme-hooks.md
+++ b/docs/front-office/theme-hooks.md
@@ -117,7 +117,8 @@ The default Flexy theme declares the following points. Names use the `page.zone.
 
 | Point | Location |
 |-------|----------|
-| `layout.head` | `<head>` of every page |
+| `layout.head.top` | Start of `<head>`, before anything the theme emits |
+| `layout.head.bottom` | End of `<head>` |
 | `layout.body.top` | Start of `<body>` |
 | `layout.header.bottom` | Below the header |
 | `layout.footer.top` | Above the footer |
@@ -135,6 +136,10 @@ The default Flexy theme declares the following points. Names use the `page.zone.
 | `checkout.bottom` | Bottom of the checkout page |
 | `account.top` | Top of the customer account page |
 | `account.bottom` | Bottom of the customer account page |
+| `account-order.top` | Top of an order in the account |
+| `account-order.item.top` | Above an order line |
+| `account-order.item.bottom` | Below an order line |
+| `account-order.bottom` | Bottom of an order in the account |
 | `order-placed.top` | Top of the order confirmation page |
 | `order-placed.bottom` | Bottom of the order confirmation page |
 
@@ -144,7 +149,8 @@ The page-level points pass their main entity as a parameter (`product`, `categor
 
 The layout points are designed with tracking and SEO modules in mind:
 
-- `layout.head`: meta tags, JSON-LD structured data, analytics loader scripts (Google Tag Manager, Matomo, ...)
+- `layout.head.top`: the `<title>`, the meta description, the canonical link, hreflang tags and JSON-LD structured data
+- `layout.head.bottom`: analytics loader scripts (Google Tag Manager, Matomo, ...)
 - `layout.body.top`: the `noscript` counterpart a tag manager requires right after the opening `body` tag
 - `layout.body.bottom`: deferred scripts
 
@@ -155,17 +161,21 @@ final readonly class TagManagerThemeHook implements ThemeHookInterface
 {
     public function supports(string $hookName): bool
     {
-        return \in_array($hookName, ['layout.head', 'layout.body.top'], true);
+        return \in_array($hookName, ['layout.head.bottom', 'layout.body.top'], true);
     }
 
     public function render(string $hookName, array $parameters): string
     {
         return match ($hookName) {
-            'layout.head' => $this->twig->render('@AcmeTagManagerModule/theme-hook/script.html.twig'),
+            'layout.head.bottom' => $this->twig->render('@AcmeTagManagerModule/theme-hook/script.html.twig'),
             'layout.body.top' => $this->twig->render('@AcmeTagManagerModule/theme-hook/noscript.html.twig'),
         };
     }
 }
 ```
 
-The layout points pass no parameters. A handler that needs to know which page is being rendered (an SEO module emitting page-specific tags, for instance) injects Symfony's `RequestStack` and reads the current request itself.
+The head points are how Flexy renders its own SEO tags: it emits none of them itself. It passes
+`breadcrumb`, and the `title`, `description` and `og_type` blocks the current page defined, so a
+handler can honour a page-level value and compute the rest. The SEOne module does exactly that. The
+remaining layout points pass no parameters; a handler that needs to know which page is being
+rendered injects Symfony's `RequestStack` and reads the current request itself.

--- a/docs/front-office/twig-basics.md
+++ b/docs/front-office/twig-basics.md
@@ -22,14 +22,19 @@ All pages extend a base layout:
 <!DOCTYPE html>
 <html lang="{{ lang_code }}">
     <head>
-        <title>{% block title %}{{ SEOnePageTitle() }}{% endblock %}</title>
-        {% block stylesheets %}{{ encore_entry_link_tags('app') }}{% endblock %}
-        {% block javascripts %}{{ encore_entry_script_tags('app') }}{% endblock %}
+        {# The title, meta and canonical tags are rendered by whoever answers this hook #}
+        {{ theme_hook('layout.head.top', {
+            title: block('title') is defined ? block('title')|trim : null,
+        }) }}
+        {% block stylesheets %}
+            <link rel="stylesheet" href="{{ asset('styles/app.css') }}" blocking="render">
+        {% endblock %}
+        {% block javascripts %}{{ importmap('app') }}{% endblock %}
     </head>
     <body>
-        {% block header %}{{ include('@components/Layout/Header.html.twig') }}{% endblock %}
+        {% block header %}<twig:Layouts:Header:Base />{% endblock %}
         <main>{% block body %}{% endblock %}</main>
-        {% block footer %}{{ include('@components/Layout/Footer.html.twig') }}{% endblock %}
+        {% block footer %}<twig:Layouts:Footer:Base />{% endblock %}
     </body>
 </html>
 ```
@@ -83,18 +88,36 @@ Get URL parameters using `attr()`:
 {% set categoryId = attr('category', 'id') %}
 ```
 
-### SEO functions
+### SEO tags
+
+A theme does not render its SEO tags itself. It opens a hook in the `<head>` and passes what the
+current page knows:
 
 ```twig
-<title>{{ SEOnePageTitle() }}</title>
-<meta name="description" content="{{ SEOnePageDesc() }}">
-<link rel="canonical" href="{{ SEOnePageCanonical() }}">
-{{ SEOneBreadcrumbJsonLd(breadcrumb)|raw }}
-{{ SEOneHreflang()|raw }}
+{{ theme_hook('layout.head.top', {
+    breadcrumb,
+    title:       block('title') is defined ? block('title')|trim : null,
+    description: block('meta_description') is defined ? block('meta_description')|trim : null,
+    og_type:     block('og_type') is defined ? block('og_type')|trim : null,
+}) }}
+```
+
+The SEOne module answers that hook and renders the title, the meta description, the canonical link,
+the hreflang tags and the breadcrumb JSON-LD, falling back to its own values for anything the page
+left unset. See [Theme hooks](./theme-hooks).
+
+Its Twig functions (`SEOneBreadcrumb`, `SEOnePageH1`, `SEOnePageCanonical`, `SEOneWebSite`,
+`SEOneWebPage`, `SEOneLocalBusiness`, ...) stay available for the values a page wants to read
+directly:
+
+```twig
+<h1>{{ SEOnePageH1()|default(null) ?: attr('product', 'title') }}</h1>
 ```
 
 :::note
-The `SEOne*` functions (`SEOnePageTitle`, `SEOnePageDesc`, `SEOnePageCanonical`, `SEOneBreadcrumbJsonLd`, `SEOneHreflang`, `SEOneBreadcrumb`) are **not** core Twig functions. They are provided by the SEOne module (`thelia/seone-module`), which Flexy declares as a dependency. A theme built from scratch without that module would not have these functions available.
+The `SEOne*` functions are **not** core Twig functions. They come from the SEOne module
+(`thelia/seone-module`), which Flexy declares as a dependency. A theme built without that module
+renders the head through the hook and simply gets nothing back.
 :::
 
 ### Translation
@@ -115,37 +138,41 @@ The `SEOne*` functions (`SEOnePageTitle`, `SEOnePageDesc`, `SEOnePageCanonical`,
 
 ### Twig components
 
-```twig
-{{ component('Flexy:ProductCard', {product: product}) }}
+Components are named after their class path under `components/`, with no prefix. The tag syntax is
+what Flexy uses everywhere; `:` prefixes an attribute whose value is a Twig expression rather than a
+string:
 
-{% component 'Flexy:Card' %}
-    {% block header %}Card Title{% endblock %}
-    {% block content %}Card content{% endblock %}
-{% endcomponent %}
+```twig
+<twig:Organisms:ProductCard:Base :product="product" />
+
+<twig:Molecules:Accordion:Base id="product-details" multiple>
+    <twig:Molecules:Accordion:Item value="description" open>
+        {# ... #}
+    </twig:Molecules:Accordion:Item>
+</twig:Molecules:Accordion:Base>
 ```
 
 ### LiveComponents
 
 ```twig
-{{ component('Flexy:CategoryFilters', {
-    initialCategoryId: categoryId,
-    initialPage: 1
-}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" />
 ```
 
 See [LiveComponents](./live-components) for details.
 
 ## Asset management
 
+Assets are served by AssetMapper, and paths resolve inside the theme's `assets/` directory:
+
 ```twig
 {# CSS #}
-{{ encore_entry_link_tags('app') }}
+<link rel="stylesheet" href="{{ asset('styles/app.css') }}" blocking="render">
 
 {# JavaScript #}
-{{ encore_entry_script_tags('app') }}
+{{ importmap('app') }}
 
 {# Single asset #}
-{{ asset('build/images/logo.png') }}
+{{ asset('images/logo.png') }}
 ```
 
 ## Stimulus controllers
@@ -181,7 +208,7 @@ See [LiveComponents](./live-components) for details.
 
 ```twig
 {# Good - logic in component #}
-{{ component('Flexy:ProductPrice', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 
 {# Avoid - complex business logic in template #}
 {% if someComplexCondition and anotherCondition %}

--- a/versioned_docs/version-3.0/architecture/dual-templating.md
+++ b/versioned_docs/version-3.0/architecture/dual-templating.md
@@ -29,7 +29,7 @@ Both Twig themes are Symfony bundles: their templates, components, Stimulus cont
 
 ## Front-office: Twig + Symfony UX
 
-The front-office ships as the `FlexyBundle`. Templates live at the theme root, components and PHP under `src/`.
+The front-office ships as the `FlexyBundle`. Page templates live at the theme root, components under `components/`, and the rest of the PHP under `src/`.
 
 ### Template location
 
@@ -40,10 +40,10 @@ templates/frontOffice/flexy/
 ├── product.html.twig         # product page
 ├── category.html.twig        # category page
 ├── checkout-cart.html.twig   # cart step
+├── components/               # TwigComponent / LiveComponent (namespace @Flexy)
 └── src/
-    ├── Twig/
-    │   └── DataAccessExtension.php   # registers resources() and attr()
-    └── UiComponents/         # TwigComponent / LiveComponent
+    └── Twig/
+        └── DataAccessExtension.php   # registers resources() and attr()
 ```
 
 ### Data retrieval
@@ -90,27 +90,24 @@ Read a value derived from the current route with the `attr()` Twig function (als
 
 ### Components
 
-Flexy ships TwigComponents (server-rendered) and LiveComponents (reactive, re-render on the server without a page reload). Render them with the `component()` function, using the names declared in the `#[AsTwigComponent]` / `#[AsLiveComponent]` attributes under `src/UiComponents/`:
+Flexy ships TwigComponents (server-rendered) and LiveComponents (reactive, re-render on the server without a page reload). Both live under `components/`, and both are rendered with the `<twig:...>` tag syntax:
 
 ```twig
-{# Product page LiveComponent - receives the product array #}
-{{ component('Flexy:Pages:Product', { product: product }) }}
+{# Product details LiveComponent - receives the product array #}
+<twig:Layouts:ProductDetails:Base :product="product" />
 
 {# Category listing with filters (LiveComponent) #}
-{{ component('Flexy:CategoryFilters', {
-    initialCategoryId: categoryId,
-    initialPage: page
-}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="page" />
 
 {# Cart step (LiveComponent) #}
-{{ component('Flexy:Checkout:Cart') }}
+<twig:Organisms:Cart:Base />
 
 {# Order summary (LiveComponent) #}
-{{ component('Flexy:Checkout:Summary') }}
+<twig:Organisms:Summary:Checkout />
 ```
 
 :::tip
-Component names are namespaced with colons (`Flexy:Checkout:Cart`), mirroring their folder under `src/UiComponents/`. Grep the bundle for `AsLiveComponent` / `AsTwigComponent` to discover the available components and their props.
+A component is named after its class path under `FlexyBundle\Components\`, with `\` written as `:` and no prefix: `components/Organisms/Cart/Base.php` is `Organisms:Cart:Base`. The `#[AsTwigComponent]` and `#[AsLiveComponent]` attributes carry no `name:` argument. Browse `components/` to discover what is available and read each class for its props.
 :::
 
 See [LiveComponents](../front-office/live-components.md) for building your own.

--- a/versioned_docs/version-3.0/back-office/index.md
+++ b/versioned_docs/version-3.0/back-office/index.md
@@ -77,9 +77,9 @@ templates/backOffice/default-twig/
 │   └── _delete_modal.html.twig
 ├── components/                # reusable Twig component templates (DataTable, Dashboard, ...)
 ├── form/
-│   └── bo_form_theme.html.twig    # Bootstrap 5 form theme, scoped to /admin
+│   └── bo_form_theme.html.twig    # Bootstrap 5 form theme, opted into per form
 ├── config/
-│   └── packages/twig.yaml         # registers the form theme namespace + form_themes
+│   └── packages/twig.yaml         # form theme namespace + the bo_form_themes global
 ├── assets/                    # SCSS + JS + img + flags
 │   ├── app.js
 │   ├── controllers/           # Stimulus controllers
@@ -152,8 +152,8 @@ Symfony 7 removed Doctrine annotations. Always use the PHP 8 attribute
 ## Back-office forms
 
 Build admin forms with Symfony's form component and let the bundle's `bo_form_theme.html.twig`
-render them with Bootstrap 5 markup. The theme is registered globally and scopes itself to the
-`/admin` path, so any form rendered under `/admin` gets the back-office styling automatically.
+render them with Bootstrap 5 markup. The theme is not global: a template opts into it with
+`{% form_theme form with bo_form_themes only %}`, which also keeps the front-office widgets out.
 
 ```php
 // local/modules/MyModule/src/Form/ConfigType.php
@@ -185,6 +185,8 @@ Render the form in a Twig template with the standard Symfony form helpers:
 
 ```twig
 {# local/modules/MyModule/templates/config.html.twig #}
+{% form_theme form with bo_form_themes only %}
+
 {{ form_start(form, { action: path('mymodule.admin.config.save'), method: 'post' }) }}
     {{ form_row(form.apiKey) }}
     {{ form_row(form.enabled) }}
@@ -192,15 +194,17 @@ Render the form in a Twig template with the standard Symfony form helpers:
 {{ form_end(form) }}
 ```
 
-The form theme is wired in the bundle's Twig configuration:
+The list the tag refers to is a Twig global declared in the bundle's Twig configuration:
 
 ```yaml
 # templates/backOffice/default-twig/config/packages/twig.yaml
 twig:
   paths:
     "%kernel.project_dir%/templates/backOffice/default-twig/form": BackOfficeDefaultTwigForm
-  form_themes:
-    - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
+  globals:
+    bo_form_themes:
+      - "bootstrap_5_layout.html.twig"
+      - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
 ```
 
 ## Extending the back-office with hooks

--- a/versioned_docs/version-3.0/back-office/templates-form-theme.md
+++ b/versioned_docs/version-3.0/back-office/templates-form-theme.md
@@ -126,41 +126,36 @@ Use it whenever a partial exposes block slots like `_page_header.html.twig` does
 
 ## The form theme
 
-`bo_form_theme.html.twig` is a custom Bootstrap 5 Symfony form theme. It is registered
-globally under its own `@BackOfficeDefaultTwigForm` namespace in
-`config/packages/twig.yaml`, which the bundle imports during `prependExtension()`:
+`bo_form_theme.html.twig` is a custom Bootstrap 5 Symfony form theme. It is **not** registered
+globally: neither theme is. Each side declares its own list as a Twig global, and each template
+that renders a form opts in. The back-office list is declared in `config/packages/twig.yaml`,
+which the bundle imports during `prependExtension()`:
 
 ```yaml
 # templates/backOffice/default-twig/config/packages/twig.yaml
 twig:
   paths:
     "%kernel.project_dir%/templates/backOffice/default-twig/form": BackOfficeDefaultTwigForm
-  form_themes:
-    - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
+  globals:
+    bo_form_themes:
+      - "bootstrap_5_layout.html.twig"
+      - "@BackOfficeDefaultTwigForm/bo_form_theme.html.twig"
 ```
 
-Because `form_themes` applies to every form rendered by the active Twig environment,
-including front-office Flexy templates, each block in `bo_form_theme.html.twig` is scoped
-to admin requests. It applies the Bootstrap 5 markup only when the request path starts with
-`/admin`, and otherwise defers to the Flexy front-office theme:
+`bootstrap_5_layout.html.twig` comes first, so it supplies the complete Bootstrap base, and
+`bo_form_theme.html.twig` only carries the admin refinements on top. Render a form with:
 
 ```twig
-{# templates/backOffice/default-twig/form/bo_form_theme.html.twig #}
-{%- block form_widget_simple -%}
-    {%- if app is defined and app.request and app.request.pathInfo starts with '/admin' -%}
-        {{- block('form_widget_simple', 'bootstrap_5_layout.html.twig') -}}
-    {%- else -%}
-        {{- block('form_widget_simple', '@formTwig/flexy_form_theme.html.twig') -}}
-    {%- endif -%}
-{%- endblock form_widget_simple -%}
+{% form_theme form with bo_form_themes only %}
 ```
 
-:::caution Mirror every Flexy-overridden block
-The Flexy front-office theme overrides several widgets (`password`, `textarea`, `money`,
-`percent`, `choice`, `radio`, `range`, `file`, `submit`). The back-office theme must mirror
-all of them with the same `/admin` short-circuit. Otherwise a back-office form picks up a
-Flexy wrapper. For example, the `<div data-controller="password">` wrapper breaks the
-Bootstrap input-group layout on the login form.
+The `only` keyword excludes every other theme, so an admin form can never pick up a front-office
+Flexy widget. The isolation is structural: no block has to test the request path.
+
+:::caution Every admin form needs the tag
+Without `{% form_theme form with bo_form_themes only %}`, the form renders with Symfony's default
+markup instead of the Bootstrap 5 admin widgets. Put the tag in the block that renders the form,
+before `form_start`.
 :::
 
 ## Forms are standard Symfony forms
@@ -213,11 +208,14 @@ final class BrandType extends AbstractType
 }
 ```
 
-In the template, render the form with `form_start` / `form_end`. The `bo_form_theme`
-supplies the Bootstrap 5 markup, so you only point each widget at the right field:
+In the template, opt into the admin form theme, then render the form with `form_start` /
+`form_end`. The theme supplies the Bootstrap 5 markup, so you only point each widget at the
+right field:
 
 ```twig
 {# @BackOfficeDefaultTwig/catalog/brand/edit.html.twig #}
+{% form_theme form with bo_form_themes only %}
+
 {{ form_start(form, {
     action: path('admin.brand.save', { brand_id: brand.id }),
     method: 'post',

--- a/versioned_docs/version-3.0/front-office/data-access.md
+++ b/versioned_docs/version-3.0/front-office/data-access.md
@@ -319,15 +319,15 @@ final readonly class ProductService
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\CategoryFilters;
+namespace FlexyBundle\Components\Layouts\ProductListing;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Thelia\Api\Service\DataAccess\DataAccessService;
 
-#[AsLiveComponent(name: 'Flexy:CategoryFilters')]
-class CategoryFilters
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -494,7 +494,7 @@ if ($product === null) {
 {% endfor %}
 
 {# Good - fetch all at once if possible, or use component #}
-{{ component('Flexy:ProductCard', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 ```
 
 ### Use pagination

--- a/versioned_docs/version-3.0/front-office/flexy-theme/creating-theme.md
+++ b/versioned_docs/version-3.0/front-office/flexy-theme/creating-theme.md
@@ -19,7 +19,18 @@ the guide below follows it.
 
 ## A theme is a bundle
 
-The Flexy theme registers itself as a Symfony bundle. The whole theme (services, Twig components, Live components, controllers) is autowired from the bundle's `src/` directory.
+The Flexy theme registers itself as a Symfony bundle. Services and controllers are autowired from `src/`, components from `components/`, and both directories are declared as PSR-4 roots in the theme's `composer.json`:
+
+```json
+{
+    "autoload": {
+        "psr-4": {
+            "FlexyBundle\\": "src/",
+            "FlexyBundle\\Components\\": "components/"
+        }
+    }
+}
+```
 
 ```php
 // templates/frontOffice/flexy/src/FlexyBundle.php
@@ -28,52 +39,51 @@ namespace FlexyBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
-use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Model\ConfigQuery;
 
 class FlexyBundle extends AbstractBundle
 {
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $serviceConfigurator = $container->services();
+        $container->import('../config/services.yaml');
 
-        $resourcePath = $this->getResourcePath();
-        if (is_dir($resourcePath)) {
-            $serviceConfigurator->load('FlexyBundle\\', $resourcePath)
-                ->autowire()
-                ->autoconfigure();
-        }
-
-        $serviceConfigurator->load('FlexyBundle\\UiComponents\\', $this->getUiComponentsPath())
+        $container->services()
+            ->defaults()
             ->autowire()
             ->autoconfigure();
     }
 
     public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        if (!is_dir($this->getResourcePath())) {
-            return;
-        }
-        $container->import('../config/packages/*.yaml');
-    }
+        $builder->prependExtensionConfig('twig', [
+            'paths' => [
+                \dirname(__DIR__).'/components' => 'Flexy',
+                \dirname(__DIR__).'/form' => 'FlexyForm',
+            ],
+            'globals' => [
+                'flexy_form_themes' => ['@FlexyForm/flexy_form_theme.html.twig'],
+            ],
+        ]);
 
-    private function getResourcePath(): string
-    {
-        return THELIA_TEMPLATE_DIR.TemplateDefinition::FRONT_OFFICE_SUBDIR.DS.ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME, 'default').DS.'src';
-    }
+        $builder->prependExtensionConfig('twig_component', [
+            'anonymous_template_directory' => 'frontOffice/%thelia_front_template%/components/',
+            'defaults' => [
+                'FlexyBundle\\Components\\' => [
+                    'template_directory' => '@Flexy',
+                    'name_prefix' => '',
+                ],
+            ],
+        ]);
 
-    private function getUiComponentsPath(): string
-    {
-        return THELIA_TEMPLATE_DIR.TemplateDefinition::FRONT_OFFICE_SUBDIR.DS.ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME, 'default').DS.'src'.DS.'UiComponents';
+        // AssetMapper, UX Icons, Tailwind and Stimulus are configured the same way.
     }
 }
 ```
 
 What this does:
 
-- `loadExtension()` registers every class under `FlexyBundle\` (the bundle's `src/`) and `FlexyBundle\UiComponents\` as autowired, autoconfigured services. `autoconfigure()` is what makes `#[Route]` controllers, `#[AsTwigComponent]` and `#[AsLiveComponent]` classes work without any XML.
-- `prependExtension()` imports the theme's own `config/packages/*.yaml` so the theme can ship its own framework configuration.
-- The resource path is resolved at runtime from the *active* front-office template (the `default` config key), so the bundle always points at the theme currently selected in the back office.
+- `loadExtension()` imports `config/services.yaml`, which registers both PSR-4 roots as autowired, autoconfigured services. `autoconfigure()` is what makes `#[Route]` controllers, `#[AsTwigComponent]` and `#[AsLiveComponent]` classes work without any XML.
+- `prependExtension()` configures the framework for the theme: Twig namespaces and globals, the TwigComponent defaults, AssetMapper, UX Icons, Tailwind and the Stimulus controller paths. `name_prefix: ''` is what makes component names carry no prefix.
+- Keys that must follow the *active* front-office template are written with the `%thelia_front_template%` parameter, so a theme that is installed but not active does not register its own paths.
 
 The bundle is enabled in `config/bundles.php`:
 
@@ -86,12 +96,12 @@ return [
 ```
 
 :::note
-For your own theme, create a `MyThemeBundle` class following this pattern (adjust the namespace and the `psr-4` autoload entry in `composer.json`), register it in `config/bundles.php`, and point its resource paths at your theme directory. Without a Bundle class, controllers, Twig components and Live components in your theme will never be discovered.
+For your own theme, create a `MyThemeBundle` class following this pattern (adjust the namespaces and the two `psr-4` entries in `composer.json`), register it in `config/bundles.php`, and point its Twig and component paths at your theme directory. Without a Bundle class, controllers, Twig components and Live components in your theme will never be discovered.
 :::
 
 ## Directory structure
 
-The Flexy theme lives in `templates/frontOffice/flexy/`. A theme combines flat page templates at the root, a `src/` PHP tree (the bundle code) and an `assets/` pipeline:
+The Flexy theme lives in `templates/frontOffice/flexy/`. A theme combines flat page templates at the root, a `components/` tree, a `src/` PHP tree (the bundle code) and an `assets/` pipeline:
 
 ```
 templates/frontOffice/my-theme/
@@ -129,17 +139,17 @@ templates/frontOffice/my-theme/
 ├── 404.html.twig
 ├── error.html.twig
 ├── maintenance.html.twig
-├── components/                # Twig partials (Atomic Design)
+├── components/                # Components, PHP-backed or anonymous (namespace @Flexy)
 │   ├── Atoms/
-│   ├── Layout/
+│   ├── Fields/
+│   ├── Forms/
+│   ├── Layouts/
 │   ├── Molecules/
-│   ├── Organisms/
-│   └── Page/
-├── form/                      # Form theme(s)
-├── src/                       # The bundle: Bundle class, Controllers, UiComponents
+│   └── Organisms/
+├── form/                      # Form theme (namespace @FlexyForm)
+├── src/                       # The bundle: Bundle class, Controllers, Services, DTOs
 │   ├── MyThemeBundle.php
-│   ├── Controller/
-│   └── UiComponents/          # TwigComponents and LiveComponents (PHP + .html.twig)
+│   └── Controller/
 └── assets/
     ├── app.js
     ├── controllers.json
@@ -197,7 +207,7 @@ The tags, in order:
   tag: it would point at a `dist` directory no build ever produces.
 
 :::caution
-There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required_version>` tag. The descriptor does not declare theme inheritance. To reuse Flexy from your own theme, render Flexy's components directly (`{{ component('Flexy:...') }}`, see [Using Flexy components](#using-flexy-components)) rather than declaring a parent.
+There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required_version>` tag. The descriptor does not declare theme inheritance. To reuse Flexy from your own theme, render Flexy's components directly (see [Using Flexy components](#using-flexy-components)) rather than declaring a parent.
 :::
 
 ## Creating the base layout
@@ -223,7 +233,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
 
 <body class="{% block body_class %}{% endblock %}">
     {% block header %}
-        {{ include('@components/Layout/Header/Header.html.twig') }}
+        <twig:Layouts:Header:Base />
     {% endblock %}
 
     <main {% block main_attributes %}{% endblock %}>
@@ -231,7 +241,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
     </main>
 
     {% block footer %}
-        {{ include('@components/Layout/Footer/Footer.html.twig') }}
+        <twig:Layouts:Footer:Base />
     {% endblock %}
 
     {% block body_js %}{% endblock %}
@@ -243,7 +253,7 @@ There is no `<name>`, flat `<author>`, `<description>`, `<parent>` or `<required
 `app` entrypoint declared in the theme's `importmap.php`. Both come from AssetMapper.
 
 :::note
-`@components` is a Twig namespace the theme registers in `config/packages/twig.yaml`, pointing at the theme's `components/` directory (Flexy also registers `@UiComponents` for `src/UiComponents` and `@assets` for `assets`). Always reference partials through the namespace (`@components/Layout/...`) as Flexy does, rather than a bare relative path.
+Flexy registers exactly two Twig namespaces from its bundle class: `@Flexy` for `components/` and `@FlexyForm` for `form/`. Components are usually rendered by name (`<twig:Layouts:Header:Base />`), and the namespace is used when one component template references another (`{% extends '@Flexy/Organisms/AddressCard/Base.html.twig' %}`).
 :::
 
 ## Essential pages
@@ -286,9 +296,7 @@ The homepage is served at `/` by the route named `index`. Fetch data with `resou
 
         <div class="product-grid">
             {% for product in products %}
-                {{ include('@components/Molecules/ProductCard/ProductCard.html.twig', {
-                    product: product
-                }) }}
+                <twig:Molecules:ProductCard:Base :product="product" />
             {% endfor %}
         </div>
     </section>
@@ -320,13 +328,13 @@ The current category id is read from the request attributes with `attr()`. The t
         </header>
 
         {# Delegate product listing + filters + pagination to a LiveComponent #}
-        {{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
+        <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
     </div>
 {% endblock %}
 ```
 
 :::tip
-Filtering, sorting and paginating a product grid is stateful work. Flexy delegates it to the `Flexy:CategoryFilters` LiveComponent rather than rebuilding pagination by hand in the template. See [LiveComponents](/docs/front-office/live-components).
+Filtering, sorting and paginating a product grid is stateful work. Flexy delegates it to the `Layouts:ProductListing:Base` LiveComponent rather than rebuilding pagination by hand in the template. See [LiveComponents](/docs/front-office/live-components).
 :::
 
 ### Product page (product.html.twig)
@@ -347,7 +355,7 @@ Filtering, sorting and paginating a product grid is stateful work. Flexy delegat
         <h1>{{ product.i18ns.title }}</h1>
 
         {# The add-to-cart UI (price, PSE selection, quantity) is a LiveComponent #}
-        {{ component('Flexy:Pages:Product', {product: product}) }}
+        <twig:Layouts:ProductDetails:Base :product="product" />
 
         {% if product.i18ns.description %}
             <section class="product-description">
@@ -360,20 +368,24 @@ Filtering, sorting and paginating a product grid is stateful work. Flexy delegat
 ```
 
 :::caution
-Adding to the cart is handled by the `Flexy:Pages:Product` LiveComponent, not by a plain HTML `<form>` posting to a `cart_add` route. No such route exists. If you build your own add-to-cart UI, model it on the Flexy Live component in `src/UiComponents/Pages/Product/`.
+Adding to the cart is handled by the `Layouts:ProductDetails:Base` LiveComponent, not by a plain HTML `<form>` posting to a `cart_add` route. No such route exists. If you build your own add-to-cart UI, model it on the Flexy Live component in `components/Layouts/ProductDetails/`.
 :::
 
 ## Creating components
 
 Flexy splits its UI in two places:
 
-- `components/` holds plain Twig partials organized with Atomic Design (`Atoms/`, `Molecules/`, `Organisms/`, `Layout/`, `Page/`). You `include` them through the `@components` namespace.
-- `src/UiComponents/` holds TwigComponents and LiveComponents: a PHP class plus its `.html.twig` template, rendered by name with `{{ component('Flexy:...') }}`. Flexy's own product card is one of these: `Flexy:ProductCard` (`src/UiComponents/ProductCard/`), which fetches its own price and image data.
+Everything lives in `components/`, organized with Atomic Design (`Atoms/`, `Molecules/`, `Organisms/`, `Layouts/`, `Fields/`, `Forms/`). A component is a directory:
 
-For a custom theme you can either reuse `Flexy:ProductCard` or build your own partial. The hand-built version below links to the product with `product.publicUrl` and resolves the image the same way the real Flexy `ProductCard` component does:
+- an anonymous component is a `.html.twig` file on its own;
+- a PHP-backed one adds a class next to its template, carrying a bare `#[AsTwigComponent]` or `#[AsLiveComponent]`.
+
+Either way the component is named after its path: `components/Organisms/ProductCard/Base.php` is rendered as `<twig:Organisms:ProductCard:Base />`. Flexy's own product card is one of these, and it fetches its own price and image data.
+
+For a custom theme you can either reuse `Organisms:ProductCard:Base` or build your own. The hand-built version below links to the product with `product.publicUrl` and resolves the image the same way the real one does:
 
 ```twig
-{# templates/frontOffice/my-theme/components/Molecules/ProductCard/ProductCard.html.twig #}
+{# templates/frontOffice/my-theme/components/Molecules/ProductCard/Base.html.twig #}
 <article class="product-card">
     <a href="{{ product.publicUrl }}">
         <div class="product-card-image">
@@ -401,7 +413,7 @@ For a custom theme you can either reuse `Flexy:ProductCard` or build your own pa
 The header links to real, named routes (the back-office and the Flexy controllers register them via `#[Route]` attributes):
 
 ```twig
-{# templates/frontOffice/my-theme/components/Layout/Header/Header.html.twig #}
+{# templates/frontOffice/my-theme/components/Layouts/Header/Base.html.twig #}
 <header class="site-header">
     <div class="container">
         {# Homepage route is named "index" #}
@@ -427,8 +439,8 @@ The header links to real, named routes (the back-office and the Flexy controller
                 <a href="{{ path('customer_login') }}">Login</a>
             {% endif %}
 
-            {# Cart link. Flexy renders this with its Flexy:HeaderButton TwigComponent,
-               which requires at least `text` (and usually `href`, `icon`). #}
+            {# Cart link. Flexy renders this with its Molecules:HeaderButton:Base
+               TwigComponent, which takes `text` and usually `href` and `icon`. #}
             <a href="{{ path('checkout_cart') }}" class="cart-link">Cart</a>
         </div>
     </div>
@@ -595,9 +607,9 @@ A custom theme can reuse Flexy's components instead of declaring inheritance in 
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    {{ component('Flexy:Pages:Product', {product: product}) }}
-    {{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
-    {{ component('Flexy:HeaderButton', {href: path('checkout_cart'), icon: 'cart', text: 'Cart'|trans}) }}
+    <twig:Layouts:ProductDetails:Base :product="product" />
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
+    <twig:Molecules:HeaderButton:Base href="{{ path('checkout_cart') }}" icon="cart" text="{{ 'Cart'|trans }}" />
 {% endblock %}
 ```
 

--- a/versioned_docs/version-3.0/front-office/flexy-theme/customization.md
+++ b/versioned_docs/version-3.0/front-office/flexy-theme/customization.md
@@ -54,34 +54,49 @@ Or pass it to the installer when you (re)install:
 php Thelia thelia:install --frontoffice_theme=myCustomTheme
 ```
 
-:::caution Namespace and component-prefix collisions
+:::caution Namespace and component-name collisions
 Flexy registers three project-global identifiers:
 
 - the Composer package name `thelia/flexy` (`composer.json`)
-- the PSR-4 namespace root `FlexyBundle\` (`composer.json`, `autoload.psr-4`)
-- the Twig component name prefix `Flexy` (`config/packages/twig_component.yaml`, under `FlexyBundle\UiComponents\`)
+- the PSR-4 roots `FlexyBundle\` (on `src/`) and `FlexyBundle\Components\` (on `components/`)
+- the Twig namespaces `@Flexy` and `@FlexyForm`
 
-If you install your copy alongside the original Flexy, both register `FlexyBundle\` and the `Flexy:` Twig component prefix. Symfony will load one class definition over the other, and component names like `Flexy:ProductCard` become ambiguous.
+Component names carry no prefix at all: Flexy sets `name_prefix: ''`, so a component is named after
+its class path under `FlexyBundle\Components\`. `Organisms:ProductCard:Base` is one name in the
+project, whichever theme declares it.
+
+If you install your copy alongside the original Flexy, both register the same PSR-4 roots, the same
+Twig namespaces and the same component names. Symfony loads one class definition over the other.
 
 To run both side by side, rename them in your copy:
 
-1. In `composer.json`, change the package `name` and the `autoload.psr-4` root (for example `MyThemeBundle\`).
-2. Rename the `FlexyBundle\` namespace in every PHP file under `src/` to your new root.
-3. In `config/packages/twig_component.yaml`, change the `name_prefix` and the namespace key:
+1. In `composer.json`, change the package `name` and both `autoload.psr-4` roots (for example `MyThemeBundle\` and `MyThemeBundle\Components\`).
+2. Rename the `FlexyBundle\` namespace in every PHP file under `src/` and `components/`.
+3. In your bundle class, change the Twig namespaces and the `twig_component` defaults key:
 
-```yaml
-# templates/frontOffice/myCustomTheme/config/packages/twig_component.yaml
-twig_component:
-    anonymous_template_directory: 'frontOffice/%thelia_front_template%/components/'
-    defaults:
-        MyThemeBundle\UiComponents\:
-            name_prefix: MyTheme
-            template_directory: '%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/src/UiComponents'
+```php
+// templates/frontOffice/myCustomTheme/src/MyThemeBundle.php
+$builder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'MyTheme',
+        \dirname(__DIR__).'/form' => 'MyThemeForm',
+    ],
+]);
+
+$builder->prependExtensionConfig('twig_component', [
+    'anonymous_template_directory' => 'frontOffice/%thelia_front_template%/components/',
+    'defaults' => [
+        'MyThemeBundle\\Components\\' => [
+            'template_directory' => '@MyTheme',
+            'name_prefix' => 'MyTheme',
+        ],
+    ],
+]);
 ```
 
-4. Update every `{{ component('Flexy:...') }}` call in your templates to the new prefix.
+4. Update the component calls in your templates to the prefix you chose (`<twig:MyTheme:Organisms:ProductCard:Base />`).
 
-If you only need one active front-office theme (the common case), you do not have to rename anything: keep `FlexyBundle\` and `Flexy:`, and do not require the upstream `thelia/flexy` package at the same time.
+If you only need one active front-office theme (the common case), you do not have to rename anything: keep the Flexy identifiers, and do not require the upstream `thelia/flexy` package at the same time.
 :::
 
 ## Customization strategies
@@ -97,33 +112,20 @@ If you only need one active front-office theme (the common case), you do not hav
 
 ### Tailwind configuration
 
-Flexy's `tailwind.config.js` scans the bundle's own files. The real `content` globs are relative to the theme directory:
+Tailwind v4 is CSS-first: there is no `tailwind.config.js`. `assets/styles/app.css` is the
+configuration, and it lists the directories Tailwind scans with `@source`. They are spelled out
+because the theme directory is git-ignored from the project root, which makes Tailwind's automatic
+source detection skip it:
 
-```javascript
-// templates/frontOffice/myCustomTheme/tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    content: [
-        './components/**/*.{twig,ts,js,json}',
-        './src/UiComponents/**/*.{twig,ts,js,json}',
-        './form/**/*.twig',
-        './*.twig',
-    ],
-    theme: {
-        extend: {
-            colors: {
-                // Flexy maps Tailwind colors to CSS variables.
-                // Override the variables in your CSS (see below), or add new colors here.
-                'brand': {
-                    50: '#f0f9ff',
-                    500: '#0ea5e9',
-                    700: '#0369a1',
-                },
-            },
-        },
-    },
-    plugins: [],
-};
+```css
+/* templates/frontOffice/myCustomTheme/assets/styles/app.css */
+@import "tailwindcss";
+
+@source "../../components";
+@source "../../partials";
+@source "../../*.html.twig";
+@source "../../form";
+@source "../../blocks";
 ```
 
 :::note
@@ -132,10 +134,11 @@ Flexy's default theme colors (`theme`, `theme-dark`, `grey`, `error`, ...) are d
 
 ### Custom CSS
 
-Edit the theme stylesheets under `templates/frontOffice/myCustomTheme/assets/css/`.
+Edit the theme stylesheets under `templates/frontOffice/myCustomTheme/assets/styles/`. Component CSS
+lives next to the component it styles, and `app.css` imports it.
 
 ```css
-/* templates/frontOffice/myCustomTheme/assets/css/app.css */
+/* templates/frontOffice/myCustomTheme/assets/styles/variables.css */
 
 /* Override Flexy theme variables */
 :root {
@@ -190,21 +193,23 @@ templates/frontOffice/myCustomTheme/
 ├── index.html.twig           # Homepage
 ├── product.html.twig         # Product page
 ├── category.html.twig        # Category page
-├── components/               # Anonymous Twig components (atoms / molecules / organisms)
-│   ├── Layout/
+├── components/               # Every component, PHP-backed or anonymous (namespace @Flexy)
+│   ├── Layouts/
 │   │   ├── Header/
-│   │   │   └── Header.html.twig
+│   │   │   ├── Base.php
+│   │   │   └── Base.html.twig
 │   │   └── Footer/
+│   ├── Molecules/
 │   └── Organisms/
-│       └── CategoryCard/
-│           └── CategoryCard.html.twig
-└── src/
-    └── UiComponents/         # Twig / Live components (PHP + template)
-        ├── ProductCard/
-        ├── CrossSelling/
-        └── Pages/
-            └── Product/
+│       └── ProductCard/
+│           ├── Base.php
+│           ├── Base.css
+│           └── Base.html.twig
+└── src/                      # Bundle class, controllers, DTOs, services
 ```
+
+A component is a directory holding its PHP class, its Twig template, its CSS and, when it needs one,
+its Stimulus controller. Anonymous components (no PHP class) sit in the same tree, template only.
 
 ### Modify page templates
 
@@ -222,7 +227,7 @@ templates/frontOffice/myCustomTheme/
         </div>
 
         <div class="product-info">
-            {{ component('Flexy:Pages:Product', {product: product}) }}
+            <twig:Layouts:ProductDetails:Base :product="product" />
         </div>
 
         {# Custom sections #}
@@ -242,7 +247,7 @@ templates/frontOffice/myCustomTheme/
 Categories and products are linked through their rewritten URLs, not through route-name-with-id helpers. The API resource exposes a `publicUrl` field (`Category::getPublicUrl()`, `Product::getPublicUrl()`, serialized in the `front:*:read` group). The homepage route is named `index`.
 
 ```twig
-{# templates/frontOffice/myCustomTheme/components/Layout/Header/Header.html.twig #}
+{# templates/frontOffice/myCustomTheme/components/Layouts/Header/Base.html.twig #}
 <header class="site-header">
     <div class="container">
         {# Logo points to the homepage #}
@@ -268,63 +273,67 @@ Categories and products are linked through their rewritten URLs, not through rou
         </nav>
 
         {# Cart / account actions #}
-        {{ include('@components/Organisms/HeaderNav/HeaderNav.html.twig') }}
+        <twig:Organisms:HeaderNav:Base />
     </div>
 </header>
 ```
 
 :::caution Do not build catalog links from route + id
-There is no `product_show` or `category` route taking an `{id}`. Catalog pages are served from SEO-friendly rewritten URLs. Always render a category or product link from its `publicUrl` field. For a ready-made card, feed the resource to the `CategoryCard` organism, which reads `category.publicUrl` internally:
+There is no `product_show` or `category` route taking an `{id}`. Catalog pages are served from SEO-friendly rewritten URLs. Always render a category or product link from its `publicUrl` field. For a ready-made card, pass that URL to the `CategoryCard` organism:
 
 ```twig
-{{ include('@components/Organisms/CategoryCard/CategoryCard.html.twig', {
-    category: category,
-    id: category.id
-}) }}
+<twig:Organisms:CategoryCard:Base
+    id="{{ category.id }}"
+    title="{{ category.i18ns.title }}"
+    href="{{ category.publicUrl }}"
+/>
 ```
 :::
 
 ## Component customization
 
-Flexy ships two kinds of server-rendered components under `src/UiComponents/`:
+Flexy ships two kinds of server-rendered components under `components/`:
 
-- Twig components (`#[AsTwigComponent]`) are stateless and rendered once. Example: `ProductCard`, `CrossSelling`.
-- Live components (`#[AsLiveComponent]`) are reactive and can re-render on user interaction. Example: `Pages\Product`, `CategoryFilters`.
+- Twig components (`#[AsTwigComponent]`) are stateless and rendered once. Example: `Organisms:ProductCard:Base`, `Layouts:CrossSelling:Base`.
+- Live components (`#[AsLiveComponent]`) are reactive and can re-render on user interaction. Example: `Layouts:ProductDetails:Base`, `Layouts:ProductListing:Base`.
 
 ### Modify an existing component
 
-`ProductCard` is a Twig component. It accepts either a `productId` (it then fetches the product itself) or a `product` (a `ProductDTO` or a raw array). Here is its real signature:
+`Organisms:ProductCard:Base` is a Twig component. It accepts either a `productId` (it then fetches the product itself) or a `product` (a `ProductDTO` or a raw array). Here is its real signature:
 
 ```php
 <?php
-// templates/frontOffice/myCustomTheme/src/UiComponents/ProductCard/ProductCard.php
+// templates/frontOffice/myCustomTheme/components/Organisms/ProductCard/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\ProductCard;
+namespace FlexyBundle\Components\Organisms\ProductCard;
 
 use FlexyBundle\DTO\ProductDTO;
+use FlexyBundle\Service\ProductImageResolver;
+use FlexyBundle\Service\ProductTaxationResolver;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 use Thelia\Api\Service\DataAccess\DataAccessService;
-use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 
-#[AsTwigComponent(name: 'Flexy:ProductCard', template: '@UiComponents/ProductCard/ProductCard.html.twig')]
-class ProductCard
+#[AsTwigComponent]
+class Base extends AbstractProductCard
 {
     public ?int $productId = null;
 
     public function __construct(
-        private readonly DataAccessService $dataAccessService,
-        private TaxEngine $taxEngine,
+        DataAccessService $dataAccessService,
+        ProductImageResolver $productImageResolver,
+        private readonly ProductTaxationResolver $productTaxationResolver,
     ) {
+        parent::__construct($dataAccessService, $productImageResolver);
     }
 
     #[PreMount]
     public function preMount(?array $data): void
     {
         if (isset($data['productId']) && $data['productId']) {
-            $this->productId = $data['productId'];
+            $this->productId = (int) $data['productId'];
         }
     }
 
@@ -335,31 +344,33 @@ class ProductCard
 }
 ```
 
-To customize it, edit the file in your theme: add helper methods, change the price logic, or edit the template at `src/UiComponents/ProductCard/ProductCard.html.twig`.
+To customize it, edit the file in your theme: add helper methods, change the price logic, or edit the template next to it, `components/Organisms/ProductCard/Base.html.twig`.
 
 :::caution
-`ProductCard` is a Twig component (`#[AsTwigComponent]`), not a Live component, and its data property is a typed `ProductDTO` (resolved in `mount()`), not a public `array $product` LiveProp. If you need reactivity (a property writable from the browser that triggers a re-render), create a Live component instead.
+`Organisms:ProductCard:Base` is a Twig component (`#[AsTwigComponent]`), not a Live component, and its data property is a typed `ProductDTO` (resolved in `mount()`), not a public `array $product` LiveProp. If you need reactivity (a property writable from the browser that triggers a re-render), create a Live component instead.
 :::
 
 ### Add a new Live component
 
-Create reactive components under `src/UiComponents/`. The Twig component prefix is `Flexy` (from `twig_component.yaml`), and the template directory resolves to `src/UiComponents`:
+Create reactive components under `components/`. The attribute stays bare: Flexy sets `name_prefix: ''`
+and `template_directory: '@Flexy'`, so both the component name and its template are derived from the
+class path.
 
 ```php
 <?php
-// templates/frontOffice/myCustomTheme/src/UiComponents/Newsletter/Newsletter.php
+// templates/frontOffice/myCustomTheme/components/Organisms/Newsletter/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\Newsletter;
+namespace FlexyBundle\Components\Organisms\Newsletter;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent(name: 'Flexy:Newsletter', template: '@UiComponents/Newsletter/Newsletter.html.twig')]
-class Newsletter
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -377,6 +388,9 @@ class Newsletter
     }
 }
 ```
+
+Its template is `components/Organisms/Newsletter/Base.html.twig`, and it renders as
+`<twig:Organisms:Newsletter:Base />`.
 
 See [Live Components](/docs/front-office/live-components) for the full reference.
 
@@ -430,12 +444,12 @@ See [Stimulus](/docs/front-office/stimulus) for more.
 
 ### Related products
 
-Use the `Flexy:ProductCard` Twig component to render a grid of products. To exclude the current product, use the `not_in` filter exposed by the API resource.
+Use the `Organisms:ProductCard:Base` Twig component to render a grid of products. To exclude the current product, use the `not_in` filter exposed by the API resource.
 
 ```twig
 {# product.html.twig #}
 {% block body %}
-    {{ component('Flexy:Pages:Product', {product: product}) }}
+    <twig:Layouts:ProductDetails:Base :product="product" />
 
     {# Related products in the same category #}
     <section class="related-products">
@@ -447,7 +461,7 @@ Use the `Flexy:ProductCard` Twig component to render a grid of products. To excl
         }) %}
         <div class="product-grid">
             {% for p in related %}
-                {{ component('Flexy:ProductCard', {product: p}) }}
+                <twig:Organisms:ProductCard:Base :product="p" />
             {% endfor %}
         </div>
     </section>
@@ -455,26 +469,41 @@ Use the `Flexy:ProductCard` Twig component to render a grid of products. To excl
 ```
 
 :::caution NotInFilter syntax
-The Thelia `NotInFilter` is keyed `not_in[<property>]` and expects an array of values, for example `'not_in[id]': [product.id]`. This matches the core `Flexy:CrossSelling` component, which queries `'not_in[id]' => $this->productIdsToIgnore`. The reverse form `id[not_in]` is not supported and will be ignored.
+The Thelia `NotInFilter` is keyed `not_in[<property>]` and expects an array of values, for example `'not_in[id]': [product.id]`. This matches the `Layouts:CrossSelling:Base` component, which queries `'not_in[id]' => $this->productIdsToIgnore`. The reverse form `id[not_in]` is not supported and will be ignored.
 :::
 
-`Flexy:ProductCard` accepts a `product` (a `ProductDTO` or a raw array), both handled by its `mount()` method, or a `productId` if you only have the id.
+`Organisms:ProductCard:Base` accepts a `product` (a `ProductDTO` or a raw array), both handled by its `mount()` method, or a `productId` if you only have the id.
 
 ## Form customization
 
-Flexy ships a form theme at `form/flexy_form_theme.html.twig`. To customize form rendering in your theme, edit that file (or create your own and register it). It overrides the standard Symfony form blocks:
+Flexy ships a form theme at `form/flexy_form_theme.html.twig`, reached as `@FlexyForm/flexy_form_theme.html.twig`. Each of its blocks delegates the markup to an anonymous component under `components/Fields/`, so restyling an input usually means editing the component rather than the theme:
 
 ```twig
 {# templates/frontOffice/myCustomTheme/form/flexy_form_theme.html.twig #}
 {% use 'form_div_layout.html.twig' %}
 
-{% block form_row %}
-    <div class="form-group {{ errors|length ? 'has-error' : '' }}">
-        {{ form_label(form) }}
-        {{ form_widget(form) }}
-        {{ form_errors(form) }}
-    </div>
-{% endblock %}
+{# The widget components render their own label and error, so the row adds no wrapper #}
+{%- block form_row -%}
+    {{- form_widget(form) -}}
+{%- endblock form_row -%}
+
+{%- block form_widget_simple -%}
+    {{ component('Fields:Input:Base', {
+        label: label,
+        name: full_name,
+        id: id,
+        type: type|default('text'),
+        value: value,
+        error: errors|first.message|default(false),
+        required: required,
+    }) }}
+{%- endblock form_widget_simple -%}
+```
+
+Templates apply the theme explicitly, one form at a time:
+
+```twig
+{% form_theme form with flexy_form_themes only %}
 ```
 
 See [Forms](/docs/front-office/forms) for the front-office form workflow.

--- a/versioned_docs/version-3.0/front-office/flexy-theme/index.md
+++ b/versioned_docs/version-3.0/front-office/flexy-theme/index.md
@@ -12,7 +12,7 @@ Flexy is the default front-office theme for Thelia 3. It is a Symfony bundle (`F
 Flexy provides:
 
 - A UI styled with Tailwind CSS
-- Around 50 components (25 LiveComponents + 24 TwigComponents), all auto-discovered from `src/UiComponents/`
+- 88 PHP-backed components (21 LiveComponents + 67 TwigComponents) plus a set of anonymous ones, all auto-discovered from `components/`
 - A full e-commerce flow (catalog, cart, checkout, account)
 - Server-rendered reactivity through Symfony UX LiveComponents and Stimulus
 - The routes that serve the front office, including the catch-all that renders catalog pages
@@ -26,7 +26,7 @@ The whole theme is a single Composer package of type `thelia-frontoffice-templat
 
 ```
 templates/frontOffice/flexy/
-├── composer.json              # type: thelia-frontoffice-template, autoload FlexyBundle\ → src/
+├── composer.json              # type: thelia-frontoffice-template, two PSR-4 roots
 ├── src/                       # PHP classes (PSR-4: FlexyBundle\)
 │   ├── FlexyBundle.php        # the bundle entry point
 │   ├── Controller/
@@ -35,13 +35,7 @@ templates/frontOffice/flexy/
 │   ├── EventListener/
 │   ├── Form/
 │   ├── Service/
-│   ├── Twig/
-│   └── UiComponents/          # Live & Twig Components (PHP + colocated .html.twig)
-│       ├── Pages/Product/
-│       ├── Checkout/
-│       ├── CategoryFilters/
-│       ├── CrossSelling/
-│       └── ...
+│   └── Twig/
 ├── base.html.twig             # base layout
 ├── index.html.twig            # homepage
 ├── category.html.twig         # category listing
@@ -49,46 +43,64 @@ templates/frontOffice/flexy/
 ├── checkout-*.html.twig       # checkout steps
 ├── account*.html.twig         # customer account
 ├── login.html.twig            # login page
-├── components/                # anonymous Twig components (Atoms / Molecules / Organisms / Layout)
-├── form/                      # form theme + custom field templates
+├── components/                # every component (PSR-4: FlexyBundle\Components\, namespace @Flexy)
+│   ├── Atoms/
+│   ├── Fields/
+│   ├── Forms/
+│   ├── Layouts/
+│   ├── Molecules/
+│   ├── Organisms/
+│   └── Toolkit/
+├── form/                      # form theme (namespace @FlexyForm)
 │   └── flexy_form_theme.html.twig
 ├── config/
 │   ├── views.yaml             # root templates that are not pages of their own
-│   └── packages/              # bundle config imported by the theme
+│   └── packages/              # third-party bundle config the theme ships
 ├── assets/                    # styles, icons, images, Stimulus controllers
 └── importmap.php              # AssetMapper entrypoints and JavaScript dependencies
 ```
 
 :::note
-There is no `vendor/thelia/flexy/src/` versus `templates/frontOffice/flexy/` split. The bundle is one directory. The `FlexyBundle\` namespace maps to `src/`, declared in the theme's own `composer.json`.
+There is no `vendor/thelia/flexy/src/` versus `templates/frontOffice/flexy/` split. The bundle is one directory. Its `composer.json` declares two PSR-4 roots: `FlexyBundle\` on `src/` and `FlexyBundle\Components\` on `components/`.
 :::
 
 ### How the bundle wires itself
 
-`FlexyBundle` extends Symfony's `AbstractBundle`. It loads its services with autowiring and autoconfiguration, and imports its own configuration:
+`FlexyBundle` extends Symfony's `AbstractBundle`. It loads its services from its own
+`config/services.yaml`, which registers both PSR-4 roots with autowiring and autoconfiguration:
 
 ```php
 // templates/frontOffice/flexy/src/FlexyBundle.php
 public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
 {
-    $serviceConfigurator = $container->services();
+    $container->import('../config/services.yaml');
 
-    $serviceConfigurator->load('FlexyBundle\\', $this->getResourcePath())
+    $container->services()
+        ->defaults()
         ->autowire()
         ->autoconfigure();
-
-    $serviceConfigurator->load('FlexyBundle\\UiComponents\\', $this->getUiComponentsPath())
-        ->autowire()
-        ->autoconfigure();
-}
-
-public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
-{
-    $container->import('../config/packages/*.yaml');
 }
 ```
 
-No XML. Services, components, Twig paths and the form theme are all declared through PHP attributes and the bundle's `config/packages/*.yaml`.
+Almost everything else is configured from `prependExtension()`, in PHP rather than YAML: the Twig
+paths and globals, the TwigComponent defaults, AssetMapper, UX Icons, Tailwind and the Stimulus
+controller paths. The theme's own `config/packages/` holds only third-party bundle configuration.
+
+```php
+public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+{
+    $this->prependConfigTwig($builder);
+    $this->prependConfigTwigComponent($builder);
+    $this->prependConfigAssetMapper($builder);
+    $this->prependConfigUxIcons($builder);
+    $this->prependConfigTailwind($builder);
+    $this->prependConfigStimulus($builder);
+    $this->prependConfigPackages($container);
+}
+```
+
+No XML. Services, components, Twig namespaces and the form theme are all declared through PHP
+attributes and this bundle class.
 
 ## Key pages
 
@@ -99,18 +111,22 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    {{ component('Flexy:CrossSelling', {categoryId: 1, title: 'Last seen products'|trans}) }}
+    {{ theme_hook('home.top') }}
 
-    <div class="bg-theme-lighter">
-        {{ component('Flexy:CrossSelling', {categoryId: 2, title: 'Popular products'|trans}) }}
+    <twig:Layouts:CrossSelling:Base categoryId="3" title="{{ 'Last seen products'|trans }}" />
+
+    <div class="bg-lighter">
+        <twig:Layouts:CrossSelling:Base categoryId="5" title="{{ 'Popular products'|trans }}" />
     </div>
 
-    {{ component('Flexy:ProductCategory', {title: 'Our product categories'|trans}) }}
+    <twig:Layouts:ProductCategory:Base title="{{ 'Our product categories'|trans }}" />
+
+    {{ theme_hook('home.bottom') }}
 {% endblock %}
 ```
 
-:::caution
-`Flexy:CrossSelling` requires a `categoryId`. There is no default in the PHP class, so calling it without one throws an error. See [Cross-selling](#cross-selling) below.
+:::tip
+`Layouts:CrossSelling:Base` browses one category, or the whole catalog when `categoryId` is left out. See [Cross-selling](#cross-selling) below.
 :::
 
 ### Category page (`category.html.twig`)
@@ -119,21 +135,23 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {# templates/frontOffice/flexy/category.html.twig #}
 {% extends 'base.html.twig' %}
 
-{% set categoryId = attr('category', 'id') %}
-{% set category = resources('/api/front/categories/' ~ categoryId) %}
-
 {% block body %}
-    {# Category hero #}
-    {{ component('Flexy:CatHero', {
-        title: category.i18ns.title,
-        chapo: category.i18ns.chapo,
-        breadcrumb: breadcrumb
-    }) }}
+    {% set categoryId = attr('category', 'id') %}
+    {% set category = resources('/api/front/categories/' ~ categoryId) %}
+
+    {{ theme_hook('category.top', {category: category}) }}
+
+    {# Category heading #}
+    <twig:Layouts:Subheader:Category
+        title="{{ SEOnePageH1()|default(null) ?: attr('category', 'title') }}"
+        description="{{ attr('category', 'chapo') }}"
+        :breadcrumb="breadcrumb"
+    />
 
     {# Reactive product listing with filters #}
-    {{ component('Flexy:CategoryFilters', {
-        initialCategoryId: categoryId
-    }) }}
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" />
+
+    {{ theme_hook('category.bottom', {category: category}) }}
 {% endblock %}
 ```
 
@@ -143,153 +161,187 @@ No XML. Services, components, Twig paths and the form theme are all declared thr
 {# templates/frontOffice/flexy/product.html.twig #}
 {% extends 'base.html.twig' %}
 
-{% set productId = attr('product', 'id') %}
-{% set product = resources('/api/front/products/' ~ productId) %}
-
 {% block body %}
-    <div class="ProductPage container">
+    {% set productId = attr('product', 'id') %}
+    {% set product = resources('/api/front/products/' ~ productId) %}
+
+    {{ theme_hook('product.top', {product: product}) }}
+
+    <div class="ProductPage">
         {# Breadcrumb #}
-        {{ component('Molecules:Breadcrumb:Breadcrumb', {breadcrumb: breadcrumb}) }}
+        <twig:Molecules:Breadcrumb:Base :items="breadcrumb" />
 
         {# Main product component (variant selection, add to cart) #}
-        {{ component('Flexy:Pages:Product', {product: product}) }}
+        <twig:Layouts:ProductDetails:Base :product="product" />
 
-        {# Cross-selling: categoryId is required #}
-        {{ component('Flexy:CrossSelling', {
-            categoryId: product.productCategories|first.category.id,
-            title: 'Last seen products'|trans
-        }) }}
+        {# Cross-selling in the category the product is filed under #}
+        <twig:Layouts:CrossSelling:Base
+            :categoryId="product.productCategories|first.category.id"
+            title="{{ 'Last seen products'|trans }}"
+        />
     </div>
 
     {# Add to cart toast notification #}
-    {{ component('Flexy:AddToCartToast') }}
+    <twig:Organisms:AddToCartToast:Base />
 {% endblock %}
 ```
 
 ## Components
 
-Flexy ships around 50 components in `src/UiComponents/`. The directory is the authoritative list: each PHP class carries either an `#[AsLiveComponent]` or an `#[AsTwigComponent]` attribute, and the component name is whatever that attribute declares.
+Flexy ships 88 PHP-backed components in `components/`, alongside a set of anonymous ones that are template-only. The directory is the authoritative list: each PHP class carries either an `#[AsLiveComponent]` or an `#[AsTwigComponent]` attribute.
 
 - LiveComponents (`#[AsLiveComponent]`) re-render on the server in response to user interaction (model binding, live actions). Use them for forms, filters and checkout steps.
 - TwigComponents (`#[AsTwigComponent]`) are stateless and render once. Use them for cards, layout pieces and presentational widgets.
 
-All names are prefixed with `Flexy` (configured in `config/packages/twig_component.yaml`). Call any component with the `component()` Twig function.
+### How a component is named
+
+The attributes are written bare, with no `name:` and no `template:` argument. The bundle sets
+`name_prefix: ''` and `template_directory: '@Flexy'`, so both are derived from the class path under
+`FlexyBundle\Components\`:
+
+```php
+// templates/frontOffice/flexy/components/Organisms/ProductCard/Base.php
+namespace FlexyBundle\Components\Organisms\ProductCard;
+
+#[AsTwigComponent]
+class Base { /* ... */ }
+```
+
+That class is the component `Organisms:ProductCard:Base`, its template is
+`components/Organisms/ProductCard/Base.html.twig`, and it renders as:
+
+```twig
+<twig:Organisms:ProductCard:Base :product="product" />
+```
+
+There is no `Flexy:` prefix. A component that carried one would be named `Flexy:...` only because a
+theme chose that prefix; Flexy itself does not.
 
 ### LiveComponents
 
 | Component | Purpose |
 |-----------|---------|
-| `Flexy:Pages:Product` | Full product page (variant selection, add to cart) |
-| `Flexy:CategoryFilters` | Product listing with reactive filters |
-| `Flexy:SearchBar` | Search with autocomplete |
-| `Flexy:Checkout:Cart` | Shopping cart |
-| `Flexy:Checkout:Payment` | Payment method selection |
-| `Flexy:Checkout:Summary` | Order summary |
-| `Flexy:Checkout:MiniSummary` | Compact order summary |
-| `Flexy:Checkout:Gateway` | Payment gateway step |
-| `Flexy:Checkout:Invoice` | Invoice address step |
-| `Flexy:Checkout:NextButton` | Checkout next-step button |
-| `Flexy:Checkout:PickupPointSearch` | Pickup point search (checkout) |
-| `Flexy:Checkout:PromoCodeForm` | Promo code input |
-| `Flexy:Checkout:Delivery` | Delivery step (delivery module selection) |
-| `Flexy:Checkout:Delivery:HomeDelivery` | Home delivery option |
-| `Flexy:Checkout:Delivery:PickupDelivery` | Pickup delivery option |
-| `Flexy:AccountAddressForm` | Account address form |
-| `Flexy:AccountCustomerUpdate` | Profile edit form |
-| `Flexy:AddressesForm` | Address form |
-| `Flexy:AddToCartToast` | Add-to-cart notification |
-| `Flexy:CustomerInformationForm` | Customer information form |
-| `Flexy:InvoiceAddresses` | Invoice address selection |
-| `Flexy:OrderCreator` | Order creation flow |
-| `Flexy:PaymentModules` | Payment module selection |
-| `Flexy:PickupPointSearch` | Pickup point search |
-| `Flexy:RegisterValidationCode` | Registration validation code |
+| `Layouts:ProductDetails:Base` | Product detail block (variant selection, add to cart) |
+| `Layouts:ProductListing:Base` | Product listing with reactive filters |
+| `Organisms:SearchBar:Base` | Search with autocomplete |
+| `Organisms:Cart:Base` | Shopping cart |
+| `Organisms:CartButton:Base` | Cart button with count |
+| `Organisms:Payment:Base` | Payment method selection |
+| `Organisms:Summary:Checkout` | Order summary |
+| `Organisms:Summary:Mini` | Compact order summary |
+| `Organisms:Invoice:Base` | Invoice address step |
+| `Organisms:NextButton:Base` | Checkout next-step button |
+| `Organisms:Delivery:Base` | Delivery step (delivery module selection) |
+| `Organisms:DeliveryMode:Home` | Home delivery option |
+| `Organisms:DeliveryMode:Pickup` | Pickup delivery option |
+| `Organisms:AddToCartToast:Base` | Add-to-cart notification |
+| `Forms:Address:Base` | Address form |
+| `Forms:Address:Account` | Address form in the customer account |
+| `Forms:Customer:Update` | Profile edit form |
+| `Forms:CustomerInformation:Base` | Customer information form |
+| `Forms:PickupSearch:Base` | Pickup point search |
+| `Forms:PromoCode:Base` | Promo code input |
+| `Forms:RegisterValidationCode:Base` | Registration validation code |
 
 ### TwigComponents
 
+The 67 Twig components are grouped the same way. The ones a theme reuses most often:
+
 | Component | Purpose |
 |-----------|---------|
-| `Flexy:ProductCard` | Product card in listings |
-| `Flexy:CrossSelling` | Related products carousel |
-| `Flexy:CartItem` | Single cart item |
-| `Flexy:HeaderButton` | Cart icon with count |
-| `Flexy:HeaderProfile` | User menu |
-| `Flexy:LangSelect` | Language switcher |
-| `Flexy:Blocks` | CMS blocks |
-| `Flexy:AccountHero` | Account header |
-| `Flexy:AddressCard` | Address display |
-| `Flexy:OrderCard` | Order history item |
-| `Flexy:OrderProductCard` | Order line product card |
-| `Flexy:CatHero` | Category hero |
-| `Flexy:Button` | Button |
-| `Flexy:CheckboxButton` | Checkbox button |
-| `Flexy:RadioButton` | Radio button |
-| `Flexy:InvoiceCard` | Invoice card |
-| `Flexy:PaymentCard` | Payment method card |
-| `Flexy:DeliveryTracking` | Delivery tracking display |
-| `Flexy:ProductCategory` | Product category block |
-| `Flexy:SimilarContent` | Similar content block |
-| `Flexy:Inputs:Radio` | Radio input |
-| `Flexy:Checkout:CheckoutSteps` | Checkout step indicator |
-| `Flexy:Checkout:AddressCardCheckout` | Address card in checkout |
-| `Flexy:Checkout:Delivery:StoreDelivery` | Store delivery option |
+| `Organisms:ProductCard:Base` | Product card in listings |
+| `Organisms:ProductCard:Search` | Product card in search results |
+| `Organisms:ProductCard:Order` | Product card in an order |
+| `Layouts:CrossSelling:Base` | Related products strip |
+| `Layouts:ProductCategory:Base` | Category grid block |
+| `Layouts:Header:Base` | Site header |
+| `Layouts:Footer:Base` | Site footer |
+| `Organisms:CartItem:Base` | Single cart item |
+| `Organisms:CategoryCard:Base` | Category card |
+| `Organisms:HeaderProfile:Base` | User menu |
+| `Organisms:LangSelect:Base` | Language switcher |
+| `Organisms:Blocks:Base` | CMS blocks |
+| `Organisms:AddressCard:Base` | Address display |
+| `Organisms:OrderCard:Base` | Order history item |
+| `Organisms:InvoiceCard:Base` | Invoice card |
+| `Organisms:PaymentCard:Base` | Payment method card |
+| `Organisms:DeliveryTracking:Base` | Delivery tracking display |
+| `Organisms:ProductGallery:Base` | Product image gallery |
+| `Molecules:Breadcrumb:Base` | Breadcrumb |
+| `Molecules:Button:Base` | Button |
+| `Molecules:Pagination:Base` | Pagination |
+| `Molecules:CheckoutSteps:Base` | Checkout step indicator |
+| `Molecules:Modal:Base` | Modal |
+| `Molecules:HeaderButton:Base` | Header icon button |
 
 :::note
-Watch the exact namespaces: the step indicator is `Flexy:Checkout:CheckoutSteps` (not `Flexy:CheckoutSteps`), and the promo form is `Flexy:Checkout:PromoCodeForm` (not `Flexy:PromoCodeForm`). When in doubt, open the component's PHP class in `src/UiComponents/` and read the `name:` argument of its attribute.
+Read the directory, not this table: `components/` is the source of truth, and the name of a component is its path under it. `components/Fields/` holds anonymous components (`Fields:Input:Base`, `Fields:Select:Base`, ...) that the form theme renders; they have no PHP class.
 :::
 
 ### Cross-selling
 
-`Flexy:CrossSelling` is a TwigComponent. Its PHP class exposes exactly two PHP properties:
+`Layouts:CrossSelling:Base` is a TwigComponent:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/CrossSelling/CrossSelling.php
-#[AsTwigComponent(name: 'Flexy:CrossSelling', template: '@UiComponents/CrossSelling/CrossSelling.html.twig')]
-class CrossSelling
-{
-    public string $categoryId;          // required, no default
-    public array $productIdsToIgnore = [];
+// templates/frontOffice/flexy/components/Layouts/CrossSelling/Base.php
+namespace FlexyBundle\Components\Layouts\CrossSelling;
 
-    // getProducts() fetches /api/front/products filtered by category,
-    // capped at 3 items, excluding $productIdsToIgnore
+#[AsTwigComponent]
+class Base
+{
+    private const DEFAULT_ITEMS_PER_PAGE = 4;
+
+    public int|string|null $categoryId = null;
+    public int $itemsPerPage = self::DEFAULT_ITEMS_PER_PAGE;
+
+    // mount() fetches visible products from /api/front/products, filtered by
+    // category when categoryId is set, and preloads their images and taxed prices
 }
 ```
 
 ```twig
-{# Fetch the 3 newest products of category 5, excluding the current one #}
-{{ component('Flexy:CrossSelling', {
-    categoryId: 5,
-    productIdsToIgnore: [currentProductId],
-    title: 'You may also like'|trans
-}) }}
+{# The 4 newest products of category 5 #}
+<twig:Layouts:CrossSelling:Base
+    categoryId="5"
+    title="{{ 'You may also like'|trans }}"
+/>
 ```
 
-:::caution
-`categoryId` is required. There is no `limit` property: the component always returns up to 3 products. `title` is a presentational prop read by the template, not by the PHP class.
+:::note
+`categoryId` is optional: without it the strip browses the whole catalog. `itemsPerPage` defaults to 4. `title` is a presentational prop read by the template, not by the PHP class.
 :::
 
 ### Using components
 
+The tag syntax is what the theme uses everywhere:
+
 ```twig
 {# A stateless TwigComponent #}
-{{ component('Flexy:ProductCard', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 
 {# A reactive LiveComponent #}
-{{ component('Flexy:CategoryFilters', {initialCategoryId: categoryId}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" />
 ```
 
-Anonymous components under `components/` are rendered with `include()` using the `@components` namespace:
+The `component()` function takes the same names, and is handy where a tag will not do, for instance when the name is computed:
 
 ```twig
-{{ include('@components/Layout/Header/Header.html.twig') }}
-{{ include('@components/Molecules/Breadcrumb/Breadcrumb.html.twig', {breadcrumb: breadcrumb}) }}
+{{ component('Molecules:FilterList:Base', {filters: filters}) }}
+```
+
+Component templates reference each other through the `@Flexy` namespace:
+
+```twig
+{% extends '@Flexy/Organisms/AddressCard/Base.html.twig' %}
+{{ include('@Flexy/Molecules/Pagination/Base.html.twig', pagination) }}
 ```
 
 ## Styling
 
 ### Tailwind CSS
 
-Flexy is styled with Tailwind CSS, configured in `tailwind.config.js`:
+Flexy is styled with Tailwind v4, which is CSS-first: the configuration is `assets/styles/app.css`,
+not a `tailwind.config.js`.
 
 ```twig
 <div class="container mx-auto px-4">
@@ -299,7 +351,7 @@ Flexy is styled with Tailwind CSS, configured in `tailwind.config.js`:
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         {% for product in products %}
-            {{ component('Flexy:ProductCard', {product: product}) }}
+            <twig:Organisms:ProductCard:Base :product="product" />
         {% endfor %}
     </div>
 </div>
@@ -465,43 +517,77 @@ renders the same on both PHP versions.
 
 ## Form theme
 
-Flexy ships a custom form theme at `form/flexy_form_theme.html.twig`. The `form/` directory is mapped to the `@formTwig` Twig namespace by the bundle's `config/packages/twig.yaml`, and the theme is applied globally in the same file:
-
-```yaml
-# templates/frontOffice/flexy/config/packages/twig.yaml
-twig:
-  paths:
-    "%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/form": formTwig
-  form_themes:
-    - "frontOffice/%thelia_front_template%/form/flexy_form_theme.html.twig"
-```
-
-Because the theme is registered globally, you usually do not need a per-form `{% form_theme %}` tag: every form rendered in the front office already uses it. To override it for a single form, reference the theme by its namespace:
+Flexy ships a custom form theme at `form/flexy_form_theme.html.twig`, reached through the
+`@FlexyForm` namespace. The theme is deliberately not registered globally, because a global form
+theme would also restyle the back office. Instead the bundle publishes the list as a Twig global,
+and each template that renders a form opts in:
 
 ```twig
-{% form_theme myForm '@formTwig/flexy_form_theme.html.twig' %}
-{{ form_widget(myForm) }}
+{% form_theme form with flexy_form_themes only %}
+{{ form_widget(form) }}
 ```
 
+Both the namespace and the global come from `FlexyBundle::prependExtension()`:
+
+```php
+// templates/frontOffice/flexy/src/FlexyBundle.php
+$containerBuilder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'Flexy',
+        \dirname(__DIR__).'/form' => 'FlexyForm',
+    ],
+    'globals' => [
+        'flexy_form_themes' => [
+            '@FlexyForm/flexy_form_theme.html.twig',
+        ],
+    ],
+]);
+```
+
+The form theme itself renders each widget through an anonymous component under `components/Fields/`,
+so restyling an input means editing that component rather than the theme file.
+
 :::caution
-The `@Flexy` Twig namespace does not exist in this bundle. Form-related templates use `@formTwig`, components use `@components` and `@UiComponents`.
+Forget the tag and the form falls back to Symfony's default markup. The `only` keyword matters too:
+it is what keeps the back-office widgets out of a front-office form.
 :::
 
 ## SEO features
 
-The base layout uses functions from the SEOne module to render titles, meta and structured data:
+The base layout does not render the title, the meta description, the canonical link, the hreflang
+tags or the breadcrumb JSON-LD itself. It opens a theme hook and lets a module answer:
 
 ```twig
 {# templates/frontOffice/flexy/base.html.twig (excerpt) #}
-<title>{{ SEOnePageTitle() }}</title>
-<meta name="description" content="{{ SEOnePageDesc() }}">
-<link rel="canonical" href="{{ SEOnePageCanonical() }}"/>
-{{ SEOneBreadcrumbJsonLd(breadcrumb)|raw }}
-{{ SEOneHreflang()|raw }}
+{{ theme_hook('layout.head.top', {
+    breadcrumb,
+    title:       block('title') is defined ? block('title')|trim : null,
+    description: block('meta_description') is defined ? block('meta_description')|trim : null,
+    og_type:     block('og_type') is defined ? block('og_type')|trim : null,
+}) }}
+
+{# ... #}
+
+{{ theme_hook('layout.head.bottom', {breadcrumb}) }}
 ```
 
+A page fills the `title`, `meta_description` and `og_type` blocks, and the hook receives whatever
+they contain. The SEOne module answers both head hooks and falls back to its own computed values for
+anything a page leaves unset. With no module answering, the head renders without those tags rather
+than breaking.
+
+The layout still emits what belongs to the theme: `og:image`, `og:locale`, `og:site_name`,
+`twitter:card`, the favicons and an empty `{% block robots %}` that pages such as the checkout fill
+with `noindex, follow`.
+
+Pages also call SEOne's Twig functions directly where the value is page-specific: `SEOneBreadcrumb()`
+in the layout, `SEOnePageH1()` on the product and category pages, `SEOneWebSite()` / `SEOneWebPage()`
+/ `SEOneLocalBusiness()` in the `structured_data` block of the homepage.
+
 :::note
-These functions are provided by the SEOne module (a Flexy dependency), not by Thelia core.
+`theme_hook()` is a core Thelia function, and a module answers it by implementing
+`Thelia\Core\Hook\Theme\ThemeHookInterface`. The `SEOne*` functions are provided by the SEOne module,
+not by the core. See [Theme hooks](/docs/front-office/theme-hooks) for writing your own handler.
 :::
 
 ## Installation

--- a/versioned_docs/version-3.0/front-office/forms.md
+++ b/versioned_docs/version-3.0/front-office/forms.md
@@ -47,11 +47,11 @@ Inject `Thelia\Core\Form\FormServiceInterface`. A no-op default implementation i
 
 ## A LiveComponent form
 
-The Flexy theme exposes its forms as LiveComponents. A good example is `AccountCustomerUpdate`, the "edit my profile" component:
+The Flexy theme exposes its forms as LiveComponents, grouped under `components/Forms/`. A good example is `Forms:Customer:Update`, the "edit my profile" component:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/AccountCustomerUpdate/AccountCustomerUpdate.php
-namespace FlexyBundle\UiComponents\AccountCustomerUpdate;
+// templates/frontOffice/flexy/components/Forms/Customer/Update.php
+namespace FlexyBundle\Components\Forms\Customer;
 
 use FlexyBundle\Form\CustomerUpdateForm;
 use Symfony\Component\Form\FormInterface;
@@ -59,14 +59,11 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
-use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\Form\FormServiceInterface;
+use Thelia\Domain\Customer\CustomerFacade;
 
-#[AsLiveComponent(
-    name: 'Flexy:AccountCustomerUpdate',
-    template: '@UiComponents/AccountCustomerUpdate/AccountCustomerUpdate.html.twig'
-)]
-class AccountCustomerUpdate extends BaseFrontController
+#[AsLiveComponent]
+class Update
 {
     use ComponentWithFormTrait;
     use DefaultActionTrait;
@@ -76,6 +73,7 @@ class AccountCustomerUpdate extends BaseFrontController
 
     public function __construct(
         private readonly FormServiceInterface $formService,
+        private readonly CustomerFacade $customerFacade,
     ) {
     }
 
@@ -88,23 +86,25 @@ class AccountCustomerUpdate extends BaseFrontController
 
 Three pieces make this a form component:
 
-- `#[AsLiveComponent]` registers it and binds it to a Twig template.
+- `#[AsLiveComponent]` registers it. It carries no argument: the component is named after its class path (`Forms:Customer:Update`) and its template is the `Update.html.twig` sitting next to it.
 - `ComponentWithFormTrait` wires the Symfony form lifecycle (rendering, hydration, submission) and requires you to implement `instantiateForm()`.
 - `DefaultActionTrait` provides the default re-render action triggered by LiveProp changes.
 
 `instantiateForm()` returns the form built by `$this->formService->getFormByName(...)`. Here the name comes from a Flexy form class constant (`CustomerUpdateForm::FORM_NAME`), but it can equally be a `FrontForm` constant.
 
-:::caution Prefer constructor injection over `extends BaseFrontController`
-Flexy components extend `Thelia\Controller\Front\BaseFrontController`. That base class exposes container helpers (a service-locator style). It is convenient, but it hides dependencies, so treat it as an anti-pattern. For your own components, prefer plain constructor injection of the exact services you need, as shown above with `FormServiceInterface`. Extending `BaseFrontController` is documented here only because it is what the current Flexy theme does.
+:::tip Inject, do not inherit
+A form component needs no base class. Inject the exact services you need, as above with
+`FormServiceInterface` and `CustomerFacade`. A few Flexy components extend Symfony's
+`AbstractController`, but only where they genuinely use its helpers.
 :::
 
 ## Handling submission with a LiveAction
 
-Add a `#[LiveAction]` method that calls `submitForm()` then checks validity. The `PromoCodeForm` checkout component shows the pattern:
+Add a `#[LiveAction]` method that calls `submitForm()` then checks validity. The `Forms:PromoCode:Base` component shows the pattern:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/Checkout/PromoCodeForm/PromoCodeForm.php
-namespace FlexyBundle\UiComponents\Checkout\PromoCodeForm;
+// templates/frontOffice/flexy/components/Forms/PromoCode/Base.php
+namespace FlexyBundle\Components\Forms\PromoCode;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
@@ -112,18 +112,14 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
-use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\Event\Coupon\CouponConsumeEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Form\FormServiceInterface;
 use Thelia\Domain\Cart\CartFacade;
 use Thelia\Form\CouponCode;
 
-#[AsLiveComponent(
-    name: 'Flexy:Checkout:PromoCodeForm',
-    template: '@UiComponents/Checkout/PromoCodeForm/PromoCodeForm.html.twig'
-)]
-class PromoCodeForm extends BaseFrontController
+#[AsLiveComponent]
+class Base
 {
     use ComponentWithFormTrait;
     use DefaultActionTrait;
@@ -177,7 +173,9 @@ public function save(): void
 ### Template
 
 ```twig
-{# templates/frontOffice/flexy/src/UiComponents/.../SomeForm.html.twig #}
+{# templates/frontOffice/flexy/components/Forms/SomeForm/Base.html.twig #}
+{% form_theme form with flexy_form_themes only %}
+
 <div {{ attributes }}>
     {{ form_start(form) }}
         {{ form_widget(form) }}
@@ -246,25 +244,44 @@ LiveComponents can validate fields as the user types, using `data-model` binding
 
 ## Flexy form theme
 
-The Flexy theme registers its form theme globally, so widgets are styled automatically. You do not need a `{% form_theme %}` tag in each template. This is configured in the bundle's `config/packages/twig.yaml`:
-
-```yaml
-# templates/frontOffice/flexy/config/packages/twig.yaml
-twig:
-  paths:
-    "%kernel.project_dir%/templates/frontOffice/%thelia_front_template%/form": formTwig
-  form_themes:
-    - "frontOffice/%thelia_front_template%/form/flexy_form_theme.html.twig"
-```
-
-The `formTwig` Twig namespace points at the theme's `form/` directory, which is why partials reference the theme as `@formTwig/flexy_form_theme.html.twig`:
+Flexy ships its form theme at `@FlexyForm/flexy_form_theme.html.twig`. It is **not** registered as a
+global `twig.form_themes` entry: a global theme would also restyle the back-office forms. Instead the
+bundle exposes the list as a Twig global, and every template that renders a form opts in:
 
 ```twig
-{% use '@formTwig/flexy_form_theme.html.twig' %}
+{% form_theme form with flexy_form_themes only %}
 ```
 
-:::note
-Because the theme is applied via `form_themes` in `twig.yaml`, every front-office form is rendered with the Flexy widgets by default. Only add an explicit `{% form_theme form '@formTwig/flexy_form_theme.html.twig' %}` when you render a form in a context where the global theme does not apply.
+The `only` keyword keeps every other theme out, so the widgets rendered below are Flexy's and nothing
+else. Put the tag inside the block that renders the form, before `form_start`.
+
+The global and the `@FlexyForm` namespace are both declared by the bundle, in
+`FlexyBundle::prependExtension()`:
+
+```php
+// templates/frontOffice/flexy/src/FlexyBundle.php
+$containerBuilder->prependExtensionConfig('twig', [
+    'paths' => [
+        \dirname(__DIR__).'/components' => 'Flexy',
+        \dirname(__DIR__).'/form' => 'FlexyForm',
+    ],
+    'globals' => [
+        'flexy_form_themes' => [
+            '@FlexyForm/flexy_form_theme.html.twig',
+        ],
+    ],
+]);
+```
+
+A field template that reuses the theme's blocks imports them by namespace:
+
+```twig
+{% use '@FlexyForm/flexy_form_theme.html.twig' %}
+```
+
+:::caution
+A front-office form rendered without the `{% form_theme %}` tag gets Symfony's bare default markup,
+not the Flexy widgets. The back office works the same way, with its own `bo_form_themes` global.
 :::
 
 ## Plain Symfony fallback
@@ -272,7 +289,7 @@ Because the theme is applied via `form_themes` in `twig.yaml`, every front-offic
 If you need a one-off form that has no Thelia definition, you can build it inline with Symfony's `createFormBuilder()`. This is standard Symfony, not the Thelia way. Prefer a named Thelia form whenever one exists:
 
 :::caution `createFormBuilder()` requires `AbstractController`
-`createFormBuilder()` is a helper provided by Symfony's `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`. Thelia's `BaseFrontController` (used by the components above) does not extend it, so the call below only works in a component that extends `AbstractController`, as the Flexy `CategoryFilters` component does. Otherwise, inject `Symfony\Component\Form\FormFactoryInterface` and call `$this->formFactory->createBuilder()`.
+`createFormBuilder()` is a helper provided by Symfony's `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`, so the call below only works in a component that extends it, as `Layouts:ProductListing:Base` does. Otherwise, inject `Symfony\Component\Form\FormFactoryInterface` and call `$this->formFactory->createBuilder()`.
 :::
 
 ```php

--- a/versioned_docs/version-3.0/front-office/index.md
+++ b/versioned_docs/version-3.0/front-office/index.md
@@ -44,7 +44,7 @@ Front-Office Request Flow
 │    │  → DataAccessService → API Platform → Propel        │      │
 │    └─────────────────────────────────────────────────────┘      │
 │    ┌─────────────────────────────────────────────────────┐      │
-│    │  {{ component('Flexy:ProductCard', {...}) }}        │      │
+│    │  <twig:Organisms:ProductCard:Base :product=... />   │      │
 │    │  → LiveComponent (reactive)                         │      │
 │    └─────────────────────────────────────────────────────┘      │
 └─────────────────────────────────────────────────────────────────┘
@@ -79,7 +79,7 @@ LiveComponents give you reactive UI without writing JavaScript:
 
 ```twig
 {# Render a reactive product component #}
-{{ component('Flexy:Pages:Product', {product: product}) }}
+<twig:Layouts:ProductDetails:Base :product="product" />
 ```
 
 The component automatically handles:
@@ -113,12 +113,14 @@ templates/frontOffice/flexy/
 ├── product.html.twig           # Product page template
 ├── checkout-*.html.twig        # Checkout page templates
 ├── account*.html.twig          # Customer account page templates
-├── components/                 # Anonymous Twig components
+├── components/                 # Every component, namespace @Flexy
 │   ├── Atoms/                  # Smallest UI primitives (Icon, Font, ...)
+│   ├── Fields/                 # Form field markup, rendered by the form theme
+│   ├── Forms/                  # Form components (LiveComponents)
+│   ├── Layouts/                # Header, Footer, listings, ...
 │   ├── Molecules/              # Reusable UI elements
 │   ├── Organisms/              # Complex components
-│   ├── Layout/                 # Header, Footer, Hero, ...
-│   └── Page/                   # Page-level building blocks
+│   └── Toolkit/                # Component showcase pages
 ├── src/                        # PHP code (autoconfigured by FlexyBundle)
 │   ├── Controller/             # Front-office controllers
 │   ├── DTO/                    # Data Transfer Objects
@@ -127,9 +129,8 @@ templates/frontOffice/flexy/
 │   ├── Form/                   # Symfony form types
 │   ├── Service/                # Services (DeliveryService, FormService, ...)
 │   ├── Twig/                   # Twig extensions (DataAccessExtension)
-│   ├── UiComponents/           # Twig/Live components (.php + colocated .html.twig)
 │   └── FlexyBundle.php         # Bundle class (loadExtension / prependExtension)
-├── form/                       # Form theme (flexy_form_theme.html.twig + fields/)
+├── form/                       # Form theme (flexy_form_theme.html.twig), namespace @FlexyForm
 ├── assets/                     # styles, icons, images
 │   └── controllers/            # Stimulus controllers
 ├── config/
@@ -140,7 +141,7 @@ templates/frontOffice/flexy/
 ```
 
 :::note Components: anonymous vs. PHP-backed
-`components/` holds anonymous Twig components (Atoms/Molecules/Organisms/Layout/Page): pure `.html.twig` files with no PHP class. `src/UiComponents/` holds PHP-backed TwigComponents and LiveComponents, where each one is a PHP class with a colocated `.html.twig` template in the same folder.
+Both kinds live in `components/`, side by side. An anonymous component is a `.html.twig` file on its own; a PHP-backed one adds a class next to its template, in the same folder. `FlexyBundle\Components\` maps to that directory, and a component's name is its path under it: `components/Organisms/ProductCard/Base.php` is `Organisms:ProductCard:Base`.
 :::
 
 ## Section contents
@@ -177,15 +178,12 @@ A minimal category page that uses all of these concepts together:
     <h1>{{ category.i18ns.title }}</h1>
 
     {# Use a LiveComponent for filtering #}
-    {{ component('Flexy:CategoryFilters', {
-        initialCategoryId: categoryId,
-        initialPage: 1
-    }) }}
+    <twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="1" />
 
     {# Or render products directly #}
     <div class="product-grid">
         {% for product in products %}
-            {{ component('Flexy:ProductCard', {product: product}) }}
+            <twig:Organisms:ProductCard:Base :product="product" />
         {% endfor %}
     </div>
 {% endblock %}

--- a/versioned_docs/version-3.0/front-office/live-components.md
+++ b/versioned_docs/version-3.0/front-office/live-components.md
@@ -21,46 +21,45 @@ For complete LiveComponents documentation, see [symfony.com/bundles/ux-live-comp
 ## Basic structure
 
 :::info TwigComponent vs LiveComponent
-The Flexy theme uses both kinds of component, roughly half and half: `#[AsTwigComponent]` for static, render-once UI (24 components, like `ProductCard`) and `#[AsLiveComponent]` for reactive, AJAX-powered UI (25 components, like `CategoryFilters`, `Pages:Product` and `Checkout:Cart`). Reach for a LiveComponent only when the UI must re-render after the initial load. See [Stimulus](./stimulus) and the [Flexy theme overview](./flexy-theme/) for the static side.
+The Flexy theme uses both kinds of component: `#[AsTwigComponent]` for static, render-once UI (67 components, like `Organisms:ProductCard:Base`) and `#[AsLiveComponent]` for reactive, AJAX-powered UI (21 components, like `Layouts:ProductListing:Base`, `Layouts:ProductDetails:Base` and `Organisms:Cart:Base`). Reach for a LiveComponent only when the UI must re-render after the initial load. See [Stimulus](./stimulus) and the [Flexy theme overview](./flexy-theme/) for the static side.
 :::
 
-Each component lives in its own folder, which holds both the PHP class and its Twig template:
+Each component lives in its own folder under `components/`, which holds the PHP class, its Twig template and, when it needs them, its CSS and Stimulus controller:
 
 ```
-templates/frontOffice/flexy/src/UiComponents/
-    CategoryFilters/
-        CategoryFilters.php
-        CategoryFilters.html.twig
-    Pages/Product/
-        Product.php
-        Product.html.twig
-    Checkout/Cart/
-        Cart.php
-        Cart.html.twig
+templates/frontOffice/flexy/components/
+    Layouts/ProductListing/
+        Base.php
+        Base.html.twig
+        Base.css
+        base_controller.js
+    Layouts/ProductDetails/
+        Base.php
+        Base.html.twig
+    Organisms/Cart/
+        Base.php
+        Base.html.twig
 ```
 
-The PHP namespace mirrors that folder layout (`FlexyBundle\UiComponents\<Path>`), and the `template:` option points at the same folder through the `@UiComponents` Twig namespace registered by Flexy.
+The PHP namespace mirrors that folder layout (`FlexyBundle\Components\<Path>`), and the attribute needs no argument: the bundle sets `name_prefix: ''` and `template_directory: '@Flexy'`, so the component name and its template are both derived from the class path. `FlexyBundle\Components\Layouts\ProductListing\Base` is the component `Layouts:ProductListing:Base`.
 
 ### PHP component
 
 ```php
 <?php
-// templates/frontOffice/flexy/src/UiComponents/CategoryFilters/CategoryFilters.php
+// templates/frontOffice/flexy/components/Layouts/ProductListing/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\CategoryFilters;
+namespace FlexyBundle\Components\Layouts\ProductListing;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent(
-    name: 'Flexy:CategoryFilters',
-    template: '@UiComponents/CategoryFilters/CategoryFilters.html.twig'
-)]
-class CategoryFilters
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -76,10 +75,15 @@ class CategoryFilters
 }
 ```
 
+:::caution Never pass `name:` or `template:` in this theme
+No component in Flexy does. Passing them would break the convention the whole theme relies on, and
+the name would no longer match the file the template sits next to.
+:::
+
 ### Twig template
 
 ```twig
-{# templates/frontOffice/flexy/src/UiComponents/CategoryFilters/CategoryFilters.html.twig #}
+{# templates/frontOffice/flexy/components/Layouts/ProductListing/Base.html.twig #}
 <div {{ attributes }}>
     <div class="product-grid">
         {% for product in products %}
@@ -99,7 +103,7 @@ LiveComponents need `{{ attributes }}` on the single root tag to wire up the AJA
 ### Usage
 
 ```twig
-{{ component('Flexy:CategoryFilters', {categoryId: categoryId, page: 1}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" :page="1" />
 ```
 
 ## Key concepts
@@ -158,11 +162,11 @@ Use `ComponentWithFormTrait` to embed a Symfony Form. Build the Thelia form by n
 
 ```php
 <?php
-// templates/frontOffice/flexy/src/UiComponents/Pages/Product/Product.php
+// templates/frontOffice/flexy/components/Layouts/ProductDetails/Base.php
 
 declare(strict_types=1);
 
-namespace FlexyBundle\UiComponents\Pages\Product;
+namespace FlexyBundle\Components\Layouts\ProductDetails;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -174,11 +178,8 @@ use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Thelia\Core\Form\FormServiceInterface;
 use Thelia\Form\Definition\FrontForm;
 
-#[AsLiveComponent(
-    name: 'Flexy:Pages:Product',
-    template: '@UiComponents/Pages/Product/Product.html.twig'
-)]
-class Product
+#[AsLiveComponent]
+class Base
 {
     use ComponentToolsTrait;
     use ComponentWithFormTrait;
@@ -225,17 +226,14 @@ LiveComponents talk to each other with `emit()` / `#[LiveListener]`. Flexy uses 
 
 ### Emitting events
 
-The product page (`Flexy:Pages:Product`) emits an `addToCart` event after adding the line to the cart:
+The product details component (`Layouts:ProductDetails:Base`) emits an `addToCart` event after adding the line to the cart:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/Pages/Product/Product.php
+// templates/frontOffice/flexy/components/Layouts/ProductDetails/Base.php
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 
-#[AsLiveComponent(
-    name: 'Flexy:Pages:Product',
-    template: '@UiComponents/Pages/Product/Product.html.twig'
-)]
-class Product
+#[AsLiveComponent]
+class Base
 {
     use ComponentToolsTrait;
 
@@ -253,18 +251,15 @@ class Product
 
 ### Listening to events
 
-A separate component, `Flexy:AddToCartToast`, listens for that event and refreshes itself to show the confirmation toast:
+A separate component, `Organisms:AddToCartToast:Base`, listens for that event and refreshes itself to show the confirmation toast:
 
 ```php
-// templates/frontOffice/flexy/src/UiComponents/AddToCartToast/AddToCartToast.php
+// templates/frontOffice/flexy/components/Organisms/AddToCartToast/Base.php
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveListener;
 
-#[AsLiveComponent(
-    name: 'Flexy:AddToCartToast',
-    template: '@UiComponents/AddToCartToast/AddToCartToast.html.twig'
-)]
-class AddToCartToast
+#[AsLiveComponent]
+class Base
 {
     use DefaultActionTrait;
 
@@ -277,12 +272,12 @@ class AddToCartToast
 ```
 
 :::note Pick a unique event name
-The listener name must match the emitted name exactly (`'addToCart'` here). Flexy also uses constants for the checkout flow (see `FlexyBundle\UiComponents\Checkout\CheckoutEvents`) to avoid magic strings between many cooperating components.
+The listener name must match the emitted name exactly (`'addToCart'` here). Flexy also uses constants for the checkout flow (see `FlexyBundle\Event\CheckoutEvents`) to avoid magic strings between many cooperating components.
 :::
 
 ### Browser events
 
-To trigger client-side JavaScript (a [Stimulus](./stimulus) controller, for instance) rather than another component, dispatch a browser event. `Flexy:Pages:Product` does this when the selected product sale element changes:
+To trigger client-side JavaScript (a [Stimulus](./stimulus) controller, for instance) rather than another component, dispatch a browser event. `Layouts:ProductDetails:Base` does this when the selected product sale element changes:
 
 ```php
 $this->dispatchBrowserEvent('change:pse', ['pseId' => $this->currentPse['id']]);
@@ -391,13 +386,15 @@ A Thelia 3 module must declare its service namespace via the static `configureSe
 
 ### Option B: drop into the Flexy theme (simple, theme-coupled)
 
-If you only target the Flexy theme, place the component directly under the theme's `UiComponents` folder so it resolves through the existing `@UiComponents` namespace:
+If you only target the Flexy theme, place the component directly under the theme's `components/` folder so it resolves through the theme's own naming convention and the `@Flexy` namespace:
 
 ```
-templates/frontOffice/flexy/src/UiComponents/NewsletterForm/
-    NewsletterForm.php
-    NewsletterForm.html.twig
+templates/frontOffice/flexy/components/Organisms/NewsletterForm/
+    Base.php
+    Base.html.twig
 ```
+
+It is then rendered as `<twig:Organisms:NewsletterForm:Base />`, with a bare `#[AsLiveComponent]` and no `template:` argument.
 
 This is simpler but couples the component to the `flexy` theme. To override an existing Flexy template from a module instead, drop your file under `local/modules/MyModule/templates/frontOffice/flexy/`. The kernel scans that directory at boot and adds it after the active theme.
 

--- a/versioned_docs/version-3.0/front-office/stimulus.md
+++ b/versioned_docs/version-3.0/front-office/stimulus.md
@@ -97,7 +97,7 @@ Stimulus works alongside LiveComponents for client-side animations and effects:
 <div {{ attributes }}
      data-controller="animation"
      data-action="addToCart->animation#pulse">
-    {{ component('Flexy:ProductCard', {product: product}) }}
+    <twig:Organisms:ProductCard:Base :product="product" />
 </div>
 ```
 

--- a/versioned_docs/version-3.0/front-office/theme-hooks.md
+++ b/versioned_docs/version-3.0/front-office/theme-hooks.md
@@ -117,7 +117,8 @@ The default Flexy theme declares the following points. Names use the `page.zone.
 
 | Point | Location |
 |-------|----------|
-| `layout.head` | `<head>` of every page |
+| `layout.head.top` | Start of `<head>`, before anything the theme emits |
+| `layout.head.bottom` | End of `<head>` |
 | `layout.body.top` | Start of `<body>` |
 | `layout.header.bottom` | Below the header |
 | `layout.footer.top` | Above the footer |
@@ -135,6 +136,10 @@ The default Flexy theme declares the following points. Names use the `page.zone.
 | `checkout.bottom` | Bottom of the checkout page |
 | `account.top` | Top of the customer account page |
 | `account.bottom` | Bottom of the customer account page |
+| `account-order.top` | Top of an order in the account |
+| `account-order.item.top` | Above an order line |
+| `account-order.item.bottom` | Below an order line |
+| `account-order.bottom` | Bottom of an order in the account |
 | `order-placed.top` | Top of the order confirmation page |
 | `order-placed.bottom` | Bottom of the order confirmation page |
 
@@ -144,7 +149,8 @@ The page-level points pass their main entity as a parameter (`product`, `categor
 
 The layout points are designed with tracking and SEO modules in mind:
 
-- `layout.head`: meta tags, JSON-LD structured data, analytics loader scripts (Google Tag Manager, Matomo, ...)
+- `layout.head.top`: the `<title>`, the meta description, the canonical link, hreflang tags and JSON-LD structured data
+- `layout.head.bottom`: analytics loader scripts (Google Tag Manager, Matomo, ...)
 - `layout.body.top`: the `noscript` counterpart a tag manager requires right after the opening `body` tag
 - `layout.body.bottom`: deferred scripts
 
@@ -155,17 +161,21 @@ final readonly class TagManagerThemeHook implements ThemeHookInterface
 {
     public function supports(string $hookName): bool
     {
-        return \in_array($hookName, ['layout.head', 'layout.body.top'], true);
+        return \in_array($hookName, ['layout.head.bottom', 'layout.body.top'], true);
     }
 
     public function render(string $hookName, array $parameters): string
     {
         return match ($hookName) {
-            'layout.head' => $this->twig->render('@AcmeTagManagerModule/theme-hook/script.html.twig'),
+            'layout.head.bottom' => $this->twig->render('@AcmeTagManagerModule/theme-hook/script.html.twig'),
             'layout.body.top' => $this->twig->render('@AcmeTagManagerModule/theme-hook/noscript.html.twig'),
         };
     }
 }
 ```
 
-The layout points pass no parameters. A handler that needs to know which page is being rendered (an SEO module emitting page-specific tags, for instance) injects Symfony's `RequestStack` and reads the current request itself.
+The head points are how Flexy renders its own SEO tags: it emits none of them itself. It passes
+`breadcrumb`, and the `title`, `description` and `og_type` blocks the current page defined, so a
+handler can honour a page-level value and compute the rest. The SEOne module does exactly that. The
+remaining layout points pass no parameters; a handler that needs to know which page is being
+rendered injects Symfony's `RequestStack` and reads the current request itself.

--- a/versioned_docs/version-3.0/front-office/twig-basics.md
+++ b/versioned_docs/version-3.0/front-office/twig-basics.md
@@ -22,14 +22,19 @@ All pages extend a base layout:
 <!DOCTYPE html>
 <html lang="{{ lang_code }}">
     <head>
-        <title>{% block title %}{{ SEOnePageTitle() }}{% endblock %}</title>
-        {% block stylesheets %}{{ encore_entry_link_tags('app') }}{% endblock %}
-        {% block javascripts %}{{ encore_entry_script_tags('app') }}{% endblock %}
+        {# The title, meta and canonical tags are rendered by whoever answers this hook #}
+        {{ theme_hook('layout.head.top', {
+            title: block('title') is defined ? block('title')|trim : null,
+        }) }}
+        {% block stylesheets %}
+            <link rel="stylesheet" href="{{ asset('styles/app.css') }}" blocking="render">
+        {% endblock %}
+        {% block javascripts %}{{ importmap('app') }}{% endblock %}
     </head>
     <body>
-        {% block header %}{{ include('@components/Layout/Header.html.twig') }}{% endblock %}
+        {% block header %}<twig:Layouts:Header:Base />{% endblock %}
         <main>{% block body %}{% endblock %}</main>
-        {% block footer %}{{ include('@components/Layout/Footer.html.twig') }}{% endblock %}
+        {% block footer %}<twig:Layouts:Footer:Base />{% endblock %}
     </body>
 </html>
 ```
@@ -83,18 +88,36 @@ Get URL parameters using `attr()`:
 {% set categoryId = attr('category', 'id') %}
 ```
 
-### SEO functions
+### SEO tags
+
+A theme does not render its SEO tags itself. It opens a hook in the `<head>` and passes what the
+current page knows:
 
 ```twig
-<title>{{ SEOnePageTitle() }}</title>
-<meta name="description" content="{{ SEOnePageDesc() }}">
-<link rel="canonical" href="{{ SEOnePageCanonical() }}">
-{{ SEOneBreadcrumbJsonLd(breadcrumb)|raw }}
-{{ SEOneHreflang()|raw }}
+{{ theme_hook('layout.head.top', {
+    breadcrumb,
+    title:       block('title') is defined ? block('title')|trim : null,
+    description: block('meta_description') is defined ? block('meta_description')|trim : null,
+    og_type:     block('og_type') is defined ? block('og_type')|trim : null,
+}) }}
+```
+
+The SEOne module answers that hook and renders the title, the meta description, the canonical link,
+the hreflang tags and the breadcrumb JSON-LD, falling back to its own values for anything the page
+left unset. See [Theme hooks](./theme-hooks).
+
+Its Twig functions (`SEOneBreadcrumb`, `SEOnePageH1`, `SEOnePageCanonical`, `SEOneWebSite`,
+`SEOneWebPage`, `SEOneLocalBusiness`, ...) stay available for the values a page wants to read
+directly:
+
+```twig
+<h1>{{ SEOnePageH1()|default(null) ?: attr('product', 'title') }}</h1>
 ```
 
 :::note
-The `SEOne*` functions (`SEOnePageTitle`, `SEOnePageDesc`, `SEOnePageCanonical`, `SEOneBreadcrumbJsonLd`, `SEOneHreflang`, `SEOneBreadcrumb`) are **not** core Twig functions. They are provided by the SEOne module (`thelia/seone-module`), which Flexy declares as a dependency. A theme built from scratch without that module would not have these functions available.
+The `SEOne*` functions are **not** core Twig functions. They come from the SEOne module
+(`thelia/seone-module`), which Flexy declares as a dependency. A theme built without that module
+renders the head through the hook and simply gets nothing back.
 :::
 
 ### Translation
@@ -115,37 +138,41 @@ The `SEOne*` functions (`SEOnePageTitle`, `SEOnePageDesc`, `SEOnePageCanonical`,
 
 ### Twig components
 
-```twig
-{{ component('Flexy:ProductCard', {product: product}) }}
+Components are named after their class path under `components/`, with no prefix. The tag syntax is
+what Flexy uses everywhere; `:` prefixes an attribute whose value is a Twig expression rather than a
+string:
 
-{% component 'Flexy:Card' %}
-    {% block header %}Card Title{% endblock %}
-    {% block content %}Card content{% endblock %}
-{% endcomponent %}
+```twig
+<twig:Organisms:ProductCard:Base :product="product" />
+
+<twig:Molecules:Accordion:Base id="product-details" multiple>
+    <twig:Molecules:Accordion:Item value="description" open>
+        {# ... #}
+    </twig:Molecules:Accordion:Item>
+</twig:Molecules:Accordion:Base>
 ```
 
 ### LiveComponents
 
 ```twig
-{{ component('Flexy:CategoryFilters', {
-    initialCategoryId: categoryId,
-    initialPage: 1
-}) }}
+<twig:Layouts:ProductListing:Base :categoryId="categoryId" />
 ```
 
 See [LiveComponents](./live-components) for details.
 
 ## Asset management
 
+Assets are served by AssetMapper, and paths resolve inside the theme's `assets/` directory:
+
 ```twig
 {# CSS #}
-{{ encore_entry_link_tags('app') }}
+<link rel="stylesheet" href="{{ asset('styles/app.css') }}" blocking="render">
 
 {# JavaScript #}
-{{ encore_entry_script_tags('app') }}
+{{ importmap('app') }}
 
 {# Single asset #}
-{{ asset('build/images/logo.png') }}
+{{ asset('images/logo.png') }}
 ```
 
 ## Stimulus controllers
@@ -181,7 +208,7 @@ See [LiveComponents](./live-components) for details.
 
 ```twig
 {# Good - logic in component #}
-{{ component('Flexy:ProductPrice', {product: product}) }}
+<twig:Organisms:ProductCard:Base :product="product" />
 
 {# Avoid - complex business logic in template #}
 {% if someComplexCondition and anotherCondition %}


### PR DESCRIPTION
Four topics still described the previous Flexy theme. They are corrected against the theme as it ships today.

**Component names.** The theme sets `name_prefix: ''`, so components carry no `Flexy:` prefix: a component is named after its class path under `FlexyBundle\Components\`, and `#[AsTwigComponent]` / `#[AsLiveComponent]` take no `name:` or `template:` argument. `components/Organisms/ProductCard/Base.php` renders as `<twig:Organisms:ProductCard:Base />`. The component tables are rebuilt from the directory, and the examples use the tag syntax the theme uses everywhere.

**Twig namespaces.** The theme registers `@Flexy` (components) and `@FlexyForm` (form theme) from its bundle class. `@components`, `@UiComponents`, `@assets` and `@formTwig` are gone, along with the `src/UiComponents/` directory they pointed at.

**Form theme.** Neither theme is registered globally. Each side exposes a Twig global and each template opts in: `{% form_theme form with flexy_form_themes only %}` in the front office, `bo_form_themes` in the admin. The back-office pages described a global registration plus a `/admin` path switch that the theme no longer uses.

**The head.** `base.html.twig` renders no SEO tag itself. It opens `theme_hook('layout.head.top')` with the breadcrumb and the page's title, description and og_type blocks, and a module answers. The hook list said `layout.head`, which does not exist.

Along the way, the same pages lost their remaining Webpack Encore and `tailwind.config.js` references, since both were replaced by AssetMapper and Tailwind v4.

Applied to `docs/` and to `versioned_docs/version-3.0/`. `docusaurus build` passes with no new broken link.