### PR TITLE
docs: align asset build instructions on the AssetMapper back-office

### DIFF
--- a/docs/architecture/dual-templating.md
+++ b/docs/architecture/dual-templating.md
@@ -149,8 +149,8 @@ ddev exec php bin/install \
 ddev exec php Thelia template:set backOffice default-twig
 ddev exec php Thelia cache:warmup -e dev
 
-# build assets
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
+# build the stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 ```
 
 ### Bundle layout

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -114,7 +114,7 @@ Both the front-office and the back-office reference themes are Twig bundles:
 | Twig + LiveComponents | Twig + LiveComponents |
 | DataAccessService (`resources()`) | Repositories / Services |
 | Stimulus controllers | Stimulus controllers |
-| AssetMapper + Tailwind CSS | Webpack Encore + Bootstrap 5 |
+| AssetMapper + Tailwind CSS | AssetMapper + Sass + Bootstrap 5 |
 
 :::caution
 The legacy Smarty `default` back-office is still shipped for backward compatibility, but it is deprecated. New back-office work should target the `default-twig` bundle.

--- a/docs/architecture/modules-vs-bundles.md
+++ b/docs/architecture/modules-vs-bundles.md
@@ -245,7 +245,7 @@ public function loadExtension(array $config, ContainerConfigurator $container, C
 
 ### The back-office theme: BackOfficeDefaultTwigBundle
 
-The Twig back-office is also a bundle. It lives at `templates/backOffice/default-twig/`, its class is `BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle`, and it carries its own `composer.json` (`"type": "thelia-backoffice-template"`). It owns its routes (`#[Route]` attributes on its controllers), hooks, Twig templates, forms and compiled assets, following the same "themes are bundles" model.
+The Twig back-office is also a bundle. It lives at `templates/backOffice/default-twig/`, its class is `BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle`, and it carries its own `composer.json` (`"type": "thelia-backoffice-template"`). It owns its routes (`#[Route]` attributes on its controllers), hooks, Twig templates, forms and assets, following the same "themes are bundles" model.
 
 ```
 templates/backOffice/default-twig/
@@ -259,7 +259,7 @@ templates/backOffice/default-twig/
 │   ├── Twig/
 │   └── UiComponents/
 ├── components/
-├── dist/                        # Compiled assets (Webpack Encore)
+├── assets/                      # JS, SCSS and images, served through AssetMapper
 ├── composer.json                # "type": "thelia-backoffice-template"
 └── README.md
 ```

--- a/docs/back-office/components.md
+++ b/docs/back-office/components.md
@@ -241,36 +241,34 @@ for any element inside its scope, replacing the historical jQuery
 It imports `Tooltip` and `Popover` from `bootstrap` and disposes them on
 `disconnect()`, so the bridge plays nicely with dynamically inserted DOM.
 
-:::tip Controllers are auto-registered, not listed
-`assets/controllers.json` is empty on purpose. The Stimulus app is started in
-`assets/bootstrap.js` with `startStimulusApp(require.context('…/lazy-controller-loader!./controllers', …))`,
-so every `*_controller.js` in `assets/controllers/` is lazily loaded by
-identifier. You never edit `controllers.json` to register a back-office
-controller. Just add the file.
+:::tip Controllers are registered explicitly
+The Stimulus app is started in `assets/bootstrap.js`, which imports every
+controller from `assets/controllers/` and registers it under its identifier.
+AssetMapper serves these files as-is, with no build-time discovery: a new
+controller must be imported and registered in `bootstrap.js`.
 :::
 
 ## Building the assets
 
-The bundle builds its SCSS and JS with Webpack Encore. The entry point is
-`assets/app.js` (which imports `bootstrap.js`, the SCSS, Bootstrap and HTMX),
-declared in `webpack.config.js` and bridged to Stimulus with
-`.enableStimulusBridge('./assets/controllers.json')`.
+The bundle serves its assets through Symfony AssetMapper: no Node.js, no
+bundler. The entry point is `assets/app.js` (which imports `bootstrap.js`,
+Bootstrap and HTMX), loaded as an ES module, and the third-party libraries are
+committed as ES modules under `assets/vendor/`. Only the SCSS is compiled, by
+[symfonycasts/sass-bundle](https://github.com/SymfonyCasts/sass-bundle), which
+downloads a standalone `dart-sass` binary on first use:
 
 ```bash
-# install once
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install"
+# build the stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 
-# production build (encore production)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run build"
-
-# rebuild on change during development (encore dev --watch)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
+# rebuild on change during development
+ddev exec php bin/console sass:build --watch
 ```
 
-:::caution Rebuild after editing assets
-A SCSS or controller change is only visible after an Encore rebuild
-(`npm run build` or a running `npm run watch`). After editing a Twig template,
-clear the cache: `ddev exec php Thelia cache:clear -e dev`.
+:::caution Rebuild after editing SCSS
+A SCSS change is only visible after `sass:build` (or with a running
+`sass:build --watch`). JavaScript changes need no build. After editing a Twig
+template, clear the cache: `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Learn more

--- a/docs/back-office/index.md
+++ b/docs/back-office/index.md
@@ -47,16 +47,16 @@ ddev exec php bin/install \
 ddev exec php Thelia template:set backOffice default-twig
 ddev exec php Thelia cache:warmup -e dev
 
-# build the bundle assets (SCSS + JS)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
+# build the bundle stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 ```
 
 The admin is then available at `https://<your-site>.ddev.site/admin`.
 
-:::tip Watch assets during development
-While editing SCSS or Stimulus controllers, run `npm run watch` from
-`templates/backOffice/default-twig/` so the bundle assets rebuild automatically. After editing a
-Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
+:::tip Watch the stylesheet during development
+While editing SCSS, run `ddev exec php bin/console sass:build --watch` so the stylesheet rebuilds
+automatically. Stimulus controllers are served as-is by AssetMapper and need no build. After
+editing a Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Bundle structure

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -21,7 +21,6 @@ ddev start
 ddev composer config --global github-oauth.github.com <your-token>
 ddev composer install
 ddev exec php bin/install --frontoffice_theme=flexy --with-demo --with-admin
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
 ```
 
 The GitHub token is not optional: Composer reads the Thelia Flex recipes through the GitHub API,
@@ -29,8 +28,9 @@ and an anonymous call is rate-limited. Flex then falls back on auto-generated re
 saying so, and the install fails later on a message that names none of this. Any token works, no
 scope needed.
 
-`bin/install` builds the front-office assets itself. The `default-twig` back-office is the one
-build left to do by hand, because it uses Webpack Encore and ships no `dist/`.
+`bin/install` builds the assets itself: `importmap:install` and `tailwind:build` for the front
+office, `sass:build` for the back-office stylesheet. There is no npm step, and Node.js is not
+needed.
 
 See [DDEV Installation](./getting-started/ddev.md) for the full setup, or
 [Standard Installation](./getting-started/installation.md) if you prefer a local PHP and MySQL stack.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -72,10 +72,10 @@ config/packages/
 ├── monolog.yaml
 ├── nelmio_cors.yaml
 ├── security.yaml
+├── symfonycasts_sass.yaml
 ├── translation.yaml
 ├── twig.yaml
 ├── twig_component.yaml
-├── webpack_encore.yaml
 └── web_profiler.yaml
 ```
 

--- a/docs/getting-started/ddev.md
+++ b/docs/getting-started/ddev.md
@@ -59,9 +59,6 @@ ddev composer install
 # Install Thelia (Twig front-office + Twig back-office)
 ddev exec php bin/install --frontoffice_theme=flexy
 
-# Build the back-office assets
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
-
 # Open in browser
 ddev launch
 ```
@@ -75,12 +72,10 @@ gives you `https://thelia.ddev.site`; a `my-shop/` directory gives you `https://
 Run `ddev describe` to see the URLs of the current project.
 :::
 
-:::warning Build the back-office assets
-`bin/install` builds the front-office assets itself, by running `importmap:install` and
-`tailwind:build` for the active template. The `default-twig` back-office is not covered: it is
-built with Webpack Encore and its `dist/` directory is not shipped in the package, so it has to be
-built once with `npm install && npm run build`. Until then, `/admin` fails with *"Could not find
-the entrypoints file from Webpack"*.
+:::note The installer builds the assets
+`bin/install` runs `importmap:install` and `tailwind:build` for the active front-office template,
+and `sass:build` for the back-office stylesheet, so the storefront and `/admin` both answer right
+after the install.
 :::
 
 :::tip
@@ -176,10 +171,11 @@ rebuilds it as you type:
 ddev exec php Thelia tailwind:build --watch
 ```
 
-The `default-twig` back-office keeps its Webpack Encore build:
+The `default-twig` back-office follows the same model: it is served through AssetMapper, only its
+Sass stylesheet is compiled, and a watcher rebuilds it as you type:
 
 ```bash
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
+ddev exec php Thelia sass:build --watch
 ```
 
 ## Troubleshooting

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,7 +12,6 @@ Install Thelia 3 and get your store running.
 - **PHP 8.3 or 8.4** with extensions: PDO_MySQL, openssl, intl, gd, curl, dom
 - **Composer 2+**
 - **MySQL 8.0+** or **MariaDB 10.6+**
-- **Node.js and npm**, only to build the Twig back-office theme
 - A **GitHub token** for Composer, see the next section
 
 ## Give Composer a GitHub token
@@ -59,14 +58,12 @@ cd thelia
 ddev start
 ddev composer install
 ddev exec php bin/install --frontoffice_theme=flexy
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
 ddev launch
 ```
 
-`bin/install` builds the assets the active front-office theme needs, so the front office answers
-right after the install. The `default-twig` back-office is the exception: it is built with Webpack
-Encore, its `dist/` directory is not shipped in the package, and until `npm run build` has run,
-`/admin` fails with *"Could not find the entrypoints file from Webpack"*.
+`bin/install` builds the assets the active templates need — the front-office importmap and
+Tailwind stylesheet, and the back-office Sass stylesheet — so the storefront and `/admin` both
+answer right after the install.
 
 Your store is at https://thelia.ddev.site, with the back-office at `/admin`. DDEV derives that
 hostname from the directory name, so a project created in `my-shop/` answers on
@@ -90,8 +87,6 @@ composer install
 php bin/install --database_host=localhost --database_name=thelia \
     --database_user=root --database_password=secret \
     --frontoffice_theme=flexy --with-demo --with-admin
-
-(cd templates/backOffice/default-twig && npm install && npm run build)
 
 php -S localhost:8000 -t public
 ```

--- a/docs/getting-started/install-reference.md
+++ b/docs/getting-started/install-reference.md
@@ -27,23 +27,18 @@ The script runs in two phases:
 9. Runs the post-activation hooks of the modules
 10. Imports demo data (if `--with-demo`)
 11. Creates admin user (if `--with-admin`)
-12. Builds the front-office assets
+12. Builds the assets
 
-## Front-office assets
+## Assets
 
-The last step runs `importmap:install`, then `tailwind:build`. Both read the template that step 8
-selected, which is why they run at the end.
+The last step runs `importmap:install`, `tailwind:build`, then `sass:build`. All three read the
+templates that step 8 selected, which is why they run at the end. `importmap:install` and
+`tailwind:build` build the front-office assets; `sass:build` compiles the back-office stylesheet.
 
-Neither command belongs to the core: they come from packages a template requires, `symfony/asset-mapper`
-and `symfonycasts/tailwind-bundle`. `bin/install` skips whichever one the console does not carry, so a
-template built on another pipeline installs without an error.
-
-A Twig back-office such as `default-twig` is outside this: it is built with Webpack Encore, ships no
-`dist/` directory, and is built once by hand.
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build
-```
+None of these commands belongs to the core: they come from packages the templates require,
+`symfony/asset-mapper` and `symfonycasts/tailwind-bundle` for the Flexy front office,
+`symfonycasts/sass-bundle` for the `default-twig` back office. `bin/install` skips whichever one
+the console does not carry, so a template built on another pipeline installs without an error.
 
 ## Options
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -180,22 +180,12 @@ default. Host and name are required.
 
 See [Install Reference](./install-reference) for what `--skip-demo-images` and `--strict-themes` do.
 
-### 4. Build the back-office assets
+### 4. Assets
 
-The front office needs no manual step. `bin/install` runs `importmap:install` and `tailwind:build`
-for you, once the active front-office template is set, and skips whichever of the two the template
-does not provide. A theme served through AssetMapper, as Flexy is, is ready when the installer
-returns.
-
-The `default-twig` back-office is built with Webpack Encore and its `dist/` directory is not part of
-the package, so it has to be built once:
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build && cd -
-```
-
-Until that build has run, `/admin` fails with *"Could not find the entrypoints file from Webpack"*.
-The Smarty back-office template (`default`) needs no build step.
+There is no manual step. `bin/install` runs `importmap:install` and `tailwind:build` for the
+active front-office template, and `sass:build` for the back-office stylesheet, and skips whichever
+command the installed templates do not provide. Both the storefront and `/admin` are ready when
+the installer returns. The Smarty back-office template (`default`) needs no build step either.
 
 ### 5. Start the development server
 

--- a/docs/upgrading/from-twig-branch.md
+++ b/docs/upgrading/from-twig-branch.md
@@ -84,12 +84,11 @@ had compiled is gone:
 ```bash
 php Thelia importmap:install
 php Thelia tailwind:build
-
-cd templates/backOffice/default-twig && npm install && npm run build
+php Thelia sass:build
 ```
 
-The first two rebuild the front-office assets, and are what `bin/install` runs on a fresh install.
-The last one rebuilds the Twig back-office, which is on Webpack Encore and ships no `dist/`.
+The first two rebuild the front-office assets, the last one the Twig back-office stylesheet. These
+are the commands `bin/install` runs on a fresh install.
 
 Then open the front office and `/admin`, and check that both render.
 

--- a/docs/upgrading/migrate.md
+++ b/docs/upgrading/migrate.md
@@ -71,7 +71,7 @@ It is a full Symfony bundle, autonomous from the core:
 - `src/Form/`: Symfony form types
 - `src/Hook/`: back-office hooks, declared with the bundle's `#[AsHook]` attribute (auto-tagged at bundle build)
 - `form/bo_form_theme.html.twig`: a Bootstrap 5 form theme
-- `assets/`: SCSS, Stimulus controllers, images, built with npm
+- `assets/`: SCSS, Stimulus controllers, images, served through AssetMapper (the stylesheet is compiled by `sass:build`)
 
 :::caution The Smarty back-office is deprecated
 The legacy Smarty back-office (`templates/backOffice/default/`) still ships side by side with `default-twig` during the transition, but it is **no longer recommended** and is expected to be dropped in Thelia 3.1. Build new back-office work on the `default-twig` bundle.

--- a/docs/upgrading/update.md
+++ b/docs/upgrading/update.md
@@ -32,18 +32,16 @@ This command applies database schema updates, new migrations, and any required d
 ## Update assets
 
 Composer reinstalls the template packages, so whatever they had compiled is gone. Rebuild the
-front-office assets:
+assets:
 
 ```bash
 php Thelia importmap:install
 php Thelia tailwind:build
+php Thelia sass:build
 ```
 
-If the Twig back-office is active, rebuild it too. It uses Webpack Encore and ships no `dist/`:
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build
-```
+The first two rebuild the front-office assets, the last one the back-office stylesheet. Skip any
+command the console does not carry: each comes from a package the corresponding template requires.
 
 ## Clear the cache
 

--- a/versioned_docs/version-3.0/architecture/dual-templating.md
+++ b/versioned_docs/version-3.0/architecture/dual-templating.md
@@ -149,8 +149,8 @@ ddev exec php bin/install \
 ddev exec php Thelia template:set backOffice default-twig
 ddev exec php Thelia cache:warmup -e dev
 
-# build assets
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
+# build the stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 ```
 
 ### Bundle layout

--- a/versioned_docs/version-3.0/architecture/index.md
+++ b/versioned_docs/version-3.0/architecture/index.md
@@ -114,7 +114,7 @@ Both the front-office and the back-office reference themes are Twig bundles:
 | Twig + LiveComponents | Twig + LiveComponents |
 | DataAccessService (`resources()`) | Repositories / Services |
 | Stimulus controllers | Stimulus controllers |
-| AssetMapper + Tailwind CSS | Webpack Encore + Bootstrap 5 |
+| AssetMapper + Tailwind CSS | AssetMapper + Sass + Bootstrap 5 |
 
 :::caution
 The legacy Smarty `default` back-office is still shipped for backward compatibility, but it is deprecated. New back-office work should target the `default-twig` bundle.

--- a/versioned_docs/version-3.0/architecture/modules-vs-bundles.md
+++ b/versioned_docs/version-3.0/architecture/modules-vs-bundles.md
@@ -245,7 +245,7 @@ public function loadExtension(array $config, ContainerConfigurator $container, C
 
 ### The back-office theme: BackOfficeDefaultTwigBundle
 
-The Twig back-office is also a bundle. It lives at `templates/backOffice/default-twig/`, its class is `BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle`, and it carries its own `composer.json` (`"type": "thelia-backoffice-template"`). It owns its routes (`#[Route]` attributes on its controllers), hooks, Twig templates, forms and compiled assets, following the same "themes are bundles" model.
+The Twig back-office is also a bundle. It lives at `templates/backOffice/default-twig/`, its class is `BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle`, and it carries its own `composer.json` (`"type": "thelia-backoffice-template"`). It owns its routes (`#[Route]` attributes on its controllers), hooks, Twig templates, forms and assets, following the same "themes are bundles" model.
 
 ```
 templates/backOffice/default-twig/
@@ -259,7 +259,7 @@ templates/backOffice/default-twig/
 │   ├── Twig/
 │   └── UiComponents/
 ├── components/
-├── dist/                        # Compiled assets (Webpack Encore)
+├── assets/                      # JS, SCSS and images, served through AssetMapper
 ├── composer.json                # "type": "thelia-backoffice-template"
 └── README.md
 ```

--- a/versioned_docs/version-3.0/back-office/components.md
+++ b/versioned_docs/version-3.0/back-office/components.md
@@ -241,36 +241,34 @@ for any element inside its scope, replacing the historical jQuery
 It imports `Tooltip` and `Popover` from `bootstrap` and disposes them on
 `disconnect()`, so the bridge plays nicely with dynamically inserted DOM.
 
-:::tip Controllers are auto-registered, not listed
-`assets/controllers.json` is empty on purpose. The Stimulus app is started in
-`assets/bootstrap.js` with `startStimulusApp(require.context('…/lazy-controller-loader!./controllers', …))`,
-so every `*_controller.js` in `assets/controllers/` is lazily loaded by
-identifier. You never edit `controllers.json` to register a back-office
-controller. Just add the file.
+:::tip Controllers are registered explicitly
+The Stimulus app is started in `assets/bootstrap.js`, which imports every
+controller from `assets/controllers/` and registers it under its identifier.
+AssetMapper serves these files as-is, with no build-time discovery: a new
+controller must be imported and registered in `bootstrap.js`.
 :::
 
 ## Building the assets
 
-The bundle builds its SCSS and JS with Webpack Encore. The entry point is
-`assets/app.js` (which imports `bootstrap.js`, the SCSS, Bootstrap and HTMX),
-declared in `webpack.config.js` and bridged to Stimulus with
-`.enableStimulusBridge('./assets/controllers.json')`.
+The bundle serves its assets through Symfony AssetMapper: no Node.js, no
+bundler. The entry point is `assets/app.js` (which imports `bootstrap.js`,
+Bootstrap and HTMX), loaded as an ES module, and the third-party libraries are
+committed as ES modules under `assets/vendor/`. Only the SCSS is compiled, by
+[symfonycasts/sass-bundle](https://github.com/SymfonyCasts/sass-bundle), which
+downloads a standalone `dart-sass` binary on first use:
 
 ```bash
-# install once
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install"
+# build the stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 
-# production build (encore production)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run build"
-
-# rebuild on change during development (encore dev --watch)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
+# rebuild on change during development
+ddev exec php bin/console sass:build --watch
 ```
 
-:::caution Rebuild after editing assets
-A SCSS or controller change is only visible after an Encore rebuild
-(`npm run build` or a running `npm run watch`). After editing a Twig template,
-clear the cache: `ddev exec php Thelia cache:clear -e dev`.
+:::caution Rebuild after editing SCSS
+A SCSS change is only visible after `sass:build` (or with a running
+`sass:build --watch`). JavaScript changes need no build. After editing a Twig
+template, clear the cache: `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Learn more

--- a/versioned_docs/version-3.0/back-office/index.md
+++ b/versioned_docs/version-3.0/back-office/index.md
@@ -47,16 +47,16 @@ ddev exec php bin/install \
 ddev exec php Thelia template:set backOffice default-twig
 ddev exec php Thelia cache:warmup -e dev
 
-# build the bundle assets (SCSS + JS)
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
+# build the bundle stylesheet (bin/install runs it on a fresh install)
+ddev exec php bin/console sass:build
 ```
 
 The admin is then available at `https://<your-site>.ddev.site/admin`.
 
-:::tip Watch assets during development
-While editing SCSS or Stimulus controllers, run `npm run watch` from
-`templates/backOffice/default-twig/` so the bundle assets rebuild automatically. After editing a
-Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
+:::tip Watch the stylesheet during development
+While editing SCSS, run `ddev exec php bin/console sass:build --watch` so the stylesheet rebuilds
+automatically. Stimulus controllers are served as-is by AssetMapper and need no build. After
+editing a Twig template, clear the cache with `ddev exec php Thelia cache:clear -e dev`.
 :::
 
 ## Bundle structure

--- a/versioned_docs/version-3.0/contribute.md
+++ b/versioned_docs/version-3.0/contribute.md
@@ -21,7 +21,6 @@ ddev start
 ddev composer config --global github-oauth.github.com <your-token>
 ddev composer install
 ddev exec php bin/install --frontoffice_theme=flexy --with-demo --with-admin
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
 ```
 
 The GitHub token is not optional: Composer reads the Thelia Flex recipes through the GitHub API,
@@ -29,8 +28,9 @@ and an anonymous call is rate-limited. Flex then falls back on auto-generated re
 saying so, and the install fails later on a message that names none of this. Any token works, no
 scope needed.
 
-`bin/install` builds the front-office assets itself. The `default-twig` back-office is the one
-build left to do by hand, because it uses Webpack Encore and ships no `dist/`.
+`bin/install` builds the assets itself: `importmap:install` and `tailwind:build` for the front
+office, `sass:build` for the back-office stylesheet. There is no npm step, and Node.js is not
+needed.
 
 See [DDEV Installation](./getting-started/ddev.md) for the full setup, or
 [Standard Installation](./getting-started/installation.md) if you prefer a local PHP and MySQL stack.

--- a/versioned_docs/version-3.0/getting-started/configuration.md
+++ b/versioned_docs/version-3.0/getting-started/configuration.md
@@ -72,10 +72,10 @@ config/packages/
 ├── monolog.yaml
 ├── nelmio_cors.yaml
 ├── security.yaml
+├── symfonycasts_sass.yaml
 ├── translation.yaml
 ├── twig.yaml
 ├── twig_component.yaml
-├── webpack_encore.yaml
 └── web_profiler.yaml
 ```
 

--- a/versioned_docs/version-3.0/getting-started/ddev.md
+++ b/versioned_docs/version-3.0/getting-started/ddev.md
@@ -59,9 +59,6 @@ ddev composer install
 # Install Thelia (Twig front-office + Twig back-office)
 ddev exec php bin/install --frontoffice_theme=flexy
 
-# Build the back-office assets
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
-
 # Open in browser
 ddev launch
 ```
@@ -75,12 +72,10 @@ gives you `https://thelia.ddev.site`; a `my-shop/` directory gives you `https://
 Run `ddev describe` to see the URLs of the current project.
 :::
 
-:::warning Build the back-office assets
-`bin/install` builds the front-office assets itself, by running `importmap:install` and
-`tailwind:build` for the active template. The `default-twig` back-office is not covered: it is
-built with Webpack Encore and its `dist/` directory is not shipped in the package, so it has to be
-built once with `npm install && npm run build`. Until then, `/admin` fails with *"Could not find
-the entrypoints file from Webpack"*.
+:::note The installer builds the assets
+`bin/install` runs `importmap:install` and `tailwind:build` for the active front-office template,
+and `sass:build` for the back-office stylesheet, so the storefront and `/admin` both answer right
+after the install.
 :::
 
 :::tip
@@ -176,10 +171,11 @@ rebuilds it as you type:
 ddev exec php Thelia tailwind:build --watch
 ```
 
-The `default-twig` back-office keeps its Webpack Encore build:
+The `default-twig` back-office follows the same model: it is served through AssetMapper, only its
+Sass stylesheet is compiled, and a watcher rebuilds it as you type:
 
 ```bash
-ddev exec bash -c "cd templates/backOffice/default-twig && npm run watch"
+ddev exec php Thelia sass:build --watch
 ```
 
 ## Troubleshooting

--- a/versioned_docs/version-3.0/getting-started/index.md
+++ b/versioned_docs/version-3.0/getting-started/index.md
@@ -12,7 +12,6 @@ Install Thelia 3 and get your store running.
 - **PHP 8.3 or 8.4** with extensions: PDO_MySQL, openssl, intl, gd, curl, dom
 - **Composer 2+**
 - **MySQL 8.0+** or **MariaDB 10.6+**
-- **Node.js and npm**, only to build the Twig back-office theme
 - A **GitHub token** for Composer, see the next section
 
 ## Give Composer a GitHub token
@@ -59,14 +58,12 @@ cd thelia
 ddev start
 ddev composer install
 ddev exec php bin/install --frontoffice_theme=flexy
-ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
 ddev launch
 ```
 
-`bin/install` builds the assets the active front-office theme needs, so the front office answers
-right after the install. The `default-twig` back-office is the exception: it is built with Webpack
-Encore, its `dist/` directory is not shipped in the package, and until `npm run build` has run,
-`/admin` fails with *"Could not find the entrypoints file from Webpack"*.
+`bin/install` builds the assets the active templates need — the front-office importmap and
+Tailwind stylesheet, and the back-office Sass stylesheet — so the storefront and `/admin` both
+answer right after the install.
 
 Your store is at https://thelia.ddev.site, with the back-office at `/admin`. DDEV derives that
 hostname from the directory name, so a project created in `my-shop/` answers on
@@ -90,8 +87,6 @@ composer install
 php bin/install --database_host=localhost --database_name=thelia \
     --database_user=root --database_password=secret \
     --frontoffice_theme=flexy --with-demo --with-admin
-
-(cd templates/backOffice/default-twig && npm install && npm run build)
 
 php -S localhost:8000 -t public
 ```

--- a/versioned_docs/version-3.0/getting-started/install-reference.md
+++ b/versioned_docs/version-3.0/getting-started/install-reference.md
@@ -27,23 +27,18 @@ The script runs in two phases:
 9. Runs the post-activation hooks of the modules
 10. Imports demo data (if `--with-demo`)
 11. Creates admin user (if `--with-admin`)
-12. Builds the front-office assets
+12. Builds the assets
 
-## Front-office assets
+## Assets
 
-The last step runs `importmap:install`, then `tailwind:build`. Both read the template that step 8
-selected, which is why they run at the end.
+The last step runs `importmap:install`, `tailwind:build`, then `sass:build`. All three read the
+templates that step 8 selected, which is why they run at the end. `importmap:install` and
+`tailwind:build` build the front-office assets; `sass:build` compiles the back-office stylesheet.
 
-Neither command belongs to the core: they come from packages a template requires, `symfony/asset-mapper`
-and `symfonycasts/tailwind-bundle`. `bin/install` skips whichever one the console does not carry, so a
-template built on another pipeline installs without an error.
-
-A Twig back-office such as `default-twig` is outside this: it is built with Webpack Encore, ships no
-`dist/` directory, and is built once by hand.
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build
-```
+None of these commands belongs to the core: they come from packages the templates require,
+`symfony/asset-mapper` and `symfonycasts/tailwind-bundle` for the Flexy front office,
+`symfonycasts/sass-bundle` for the `default-twig` back office. `bin/install` skips whichever one
+the console does not carry, so a template built on another pipeline installs without an error.
 
 ## Options
 

--- a/versioned_docs/version-3.0/getting-started/installation.md
+++ b/versioned_docs/version-3.0/getting-started/installation.md
@@ -180,22 +180,12 @@ default. Host and name are required.
 
 See [Install Reference](./install-reference) for what `--skip-demo-images` and `--strict-themes` do.
 
-### 4. Build the back-office assets
+### 4. Assets
 
-The front office needs no manual step. `bin/install` runs `importmap:install` and `tailwind:build`
-for you, once the active front-office template is set, and skips whichever of the two the template
-does not provide. A theme served through AssetMapper, as Flexy is, is ready when the installer
-returns.
-
-The `default-twig` back-office is built with Webpack Encore and its `dist/` directory is not part of
-the package, so it has to be built once:
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build && cd -
-```
-
-Until that build has run, `/admin` fails with *"Could not find the entrypoints file from Webpack"*.
-The Smarty back-office template (`default`) needs no build step.
+There is no manual step. `bin/install` runs `importmap:install` and `tailwind:build` for the
+active front-office template, and `sass:build` for the back-office stylesheet, and skips whichever
+command the installed templates do not provide. Both the storefront and `/admin` are ready when
+the installer returns. The Smarty back-office template (`default`) needs no build step either.
 
 ### 5. Start the development server
 

--- a/versioned_docs/version-3.0/upgrading/from-twig-branch.md
+++ b/versioned_docs/version-3.0/upgrading/from-twig-branch.md
@@ -84,12 +84,11 @@ had compiled is gone:
 ```bash
 php Thelia importmap:install
 php Thelia tailwind:build
-
-cd templates/backOffice/default-twig && npm install && npm run build
+php Thelia sass:build
 ```
 
-The first two rebuild the front-office assets, and are what `bin/install` runs on a fresh install.
-The last one rebuilds the Twig back-office, which is on Webpack Encore and ships no `dist/`.
+The first two rebuild the front-office assets, the last one the Twig back-office stylesheet. These
+are the commands `bin/install` runs on a fresh install.
 
 Then open the front office and `/admin`, and check that both render.
 

--- a/versioned_docs/version-3.0/upgrading/migrate.md
+++ b/versioned_docs/version-3.0/upgrading/migrate.md
@@ -71,7 +71,7 @@ It is a full Symfony bundle, autonomous from the core:
 - `src/Form/`: Symfony form types
 - `src/Hook/`: back-office hooks, declared with the bundle's `#[AsHook]` attribute (auto-tagged at bundle build)
 - `form/bo_form_theme.html.twig`: a Bootstrap 5 form theme
-- `assets/`: SCSS, Stimulus controllers, images, built with npm
+- `assets/`: SCSS, Stimulus controllers, images, served through AssetMapper (the stylesheet is compiled by `sass:build`)
 
 :::caution The Smarty back-office is deprecated
 The legacy Smarty back-office (`templates/backOffice/default/`) still ships side by side with `default-twig` during the transition, but it is **no longer recommended** and is expected to be dropped in Thelia 3.1. Build new back-office work on the `default-twig` bundle.

--- a/versioned_docs/version-3.0/upgrading/update.md
+++ b/versioned_docs/version-3.0/upgrading/update.md
@@ -32,18 +32,16 @@ This command applies database schema updates, new migrations, and any required d
 ## Update assets
 
 Composer reinstalls the template packages, so whatever they had compiled is gone. Rebuild the
-front-office assets:
+assets:
 
 ```bash
 php Thelia importmap:install
 php Thelia tailwind:build
+php Thelia sass:build
 ```
 
-If the Twig back-office is active, rebuild it too. It uses Webpack Encore and ships no `dist/`:
-
-```bash
-cd templates/backOffice/default-twig && npm install && npm run build
-```
+The first two rebuild the front-office assets, the last one the back-office stylesheet. Skip any
+command the console does not carry: each comes from a package the corresponding template requires.
 
 ## Clear the cache
 


### PR DESCRIPTION
The `default-twig` back-office moved from Webpack Encore to AssetMapper + symfonycasts/sass-bundle (thelia-templates/default-twig#54), and `bin/install` now compiles all the assets itself, including the back-office stylesheet (thelia/thelia#3795). Node.js and npm are no longer needed anywhere.

This sweeps the 3.x docs accordingly:

- every `npm install && npm run build` instruction for the back-office becomes `php bin/console sass:build` (or is removed where `bin/install` already covers it)
- `npm run watch` becomes `sass:build --watch`
- the Node.js prerequisite is removed from Getting Started
- back-office component docs describe the AssetMapper wiring (explicit controller registration in `assets/bootstrap.js`, vendors committed under `assets/vendor/`) instead of Encore
- stale `dist/` and `webpack_encore.yaml` references are updated

The same changes are applied to `versioned_docs/version-3.0/` in a second commit: `docusaurus.config.js` sets `lastVersion: '3.0'` with an empty path, so the 3.0 snapshot — not `docs/` (the "Next" version) — is what readers get by default, and the affected files were byte-identical to `docs/` before this sweep.

The 2.x docs keep their npm instructions.